### PR TITLE
[#8640] Fixing the User/Add API function

### DIFF
--- a/www/guis/admin/application/models/Domain.php
+++ b/www/guis/admin/application/models/Domain.php
@@ -813,7 +813,7 @@ class Default_Model_Domain
 	 
 	public function loadOldDomain() {
 		if ($this->domain_) {
-			return;
+            return $this->domain_;
 		}
 		## use old stuff !
 		unset($_SESSION['_authsession']);


### PR DESCRIPTION
In the case when a local user is added through the API on a domain
configured in LDAP, an error was raised and the action did not complete.
This was due to the behaviour of the function `loadOldDomain` in
`www/guis/admin/application/models/Domain.php` which returned the old
Domain version if it did not exist, but returned nothing when it did.
The fix is simply to return the old Domain in both cases.