### PR TITLE
[#9103] Fix being unable to set summary_type

### DIFF
--- a/www/classes/user/User.php
+++ b/www/classes/user/User.php
@@ -47,6 +47,7 @@ class User extends PrefHandler {
                        'gui_graph_type' => 'bar',
                        'gui_group_quarantines' => '0',
                        'summary_to' => '',
+                       'summary_type' => 'NOTSET',
                        'allow_newsletters' => '',
         	          );	
                       


### PR DESCRIPTION
When `Configuration > Quarantine Display > Address displayed by default > All` is checked, the summary type could not be changed for the user because the field did no exist in the `PrefHandler > User` subclass. All the derived addresses were also not set, unless it was the main address.