### PR TITLE
Match the *lists case insensitively

### DIFF
--- a/lib/Email.pm
+++ b/lib/Email.pm
@@ -299,7 +299,7 @@ sub listMatch {
     $reg =~ s/\}/\\\}/g; # Escape }
     $reg =~ s/\?/\\\?/g; # Escape ?
     $reg =~ s/[^a-zA-Z0-9\+.\\\-_=@\*\$\^!#%&'\/\?`{|}~]//g; # Remove unwanted characters
-    if ($sender =~ /$reg/) {
+    if ($sender =~ /$reg/i) {
         return 1;
     }
     return 0;

--- a/lib/PrefTDaemon.pm
+++ b/lib/PrefTDaemon.pm
@@ -657,7 +657,7 @@ sub listMatch {
     $reg =~ s/\}/\\\}/g; # Escape }
     $reg =~ s/\?/\\\?/g; # Escape ?
     $reg =~ s/[^a-zA-Z0-9\+.\\\-_=@\*\$\^!#%&'\/\?`{|}~]//g; # Remove unwanted characters
-    if ($sender =~ /$reg/) {
+    if ($sender =~ /$reg/i) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
Fixes a bug in which if an entry of the white-black-warn-news list was put in uppercase, the sender was not matched if its address is not in uppercase