### PR TITLE
Newsletter whitelists are now checked versus both envelop sender and

### DIFF
--- a/lib/SpamHandler/Message.pm
+++ b/lib/SpamHandler/Message.pm
@@ -169,7 +169,7 @@ sub process {
                   ($email->hasInWhiteWarnList( 'blacklist', $this->{env_sender} ) || $email->hasInWhiteWarnList( 'blacklist', $this->{msg_form} ));
 		my @res_wnews = ('NOTIN','System','Domain','User');
 		my $nwhitelisted =
-		  $email->loadedIsWWListed( 'wnews', $this->{msg_from} );
+		  $email->loadedIsWWListed( 'wnews', $this->{msg_from} ) || $email->loadedIsWWListed( 'wnews', $this->{env_sender} );
 		$this->endTimer('Message fetch ww');
 
 		$this->{daemon}->doLog("Delivery_type: " . $delivery_type . " Blacklisted: " . $blacklisted);		


### PR DESCRIPTION
Newsletter whitelists are now used both for envelop and body sender