### PR TITLE
[#9029] Change the TNEF expander to use external

### DIFF
--- a/etc/mailscanner/MailScanner.conf_template
+++ b/etc/mailscanner/MailScanner.conf_template
@@ -50,7 +50,7 @@ Maximum Attachments Per Message = __MAXATTACHMENTS__
 Expand TNEF = __EXPANDTNEF__
 Use TNEF Contents = __USETNEFCONTENT__
 Deliver Unparsable TNEF = __DELIVERBADTNEF__
-TNEF Expander = internal
+TNEF Expander = /usr/bin/tnef
 TNEF Timeout = __TNEFTIMEOUT__
 
 File Command = /opt/file/bin/mc2-file


### PR DESCRIPTION
Using another TNEF expander in MailScanner as the internal expander often fails