### PR TITLE
Fix db synchronization issues at start

### DIFF
--- a/etc/init.d/mailcleaner
+++ b/etc/init.d/mailcleaner
@@ -53,6 +53,8 @@ if [ ! -f "${FIRSTUPDATE_FLAG_RAN}" ]; then
       touch ${FIRSTUPDATE_FLAG_RUNNING}
       echo "Updating..." >> ${FIRSTUPDATE_LOG}
       mkdir -p ${FIRSTUPDATE_FLAG_DIR}
+      ${SRCDIR}/etc/init.d/mailcleaner start
+      ${SRCDIR}/bin/resync_db.sh
       /root/Updater4MC/updater4mc.sh || rm -f ${FIRSTUPDATE_FLAG_RUNNING}  # If error during upgrade, it will try again every time
       touch ${FIRSTUPDATE_FLAG_RAN}
       echo "Finished update" >> ${FIRSTUPDATE_LOG}


### PR DESCRIPTION
As the MailCleaner is now, the Binary logs for the mysql replication
expire after 21 days. Thus when starting a new VM more than 21 days
after the VM creation, there will be a synchronization issue between the
databases.
Calling the `resync_db.sh` script on the first run allows to solve this
issue.