### PR TITLE
Use english as default summary language

### DIFF
--- a/bin/send_summary.pl
+++ b/bin/send_summary.pl
@@ -117,7 +117,8 @@ foreach my $a (@addresses) {
   my $domain = $email->getDomainObject();
   my $type = $email->getPref('summary_type');
   my $lang = $email->getPref('language');
-  if (!defined($lang) || $lang eq '') {
+  # In case of missing translation for summaries
+  if (!defined($lang) || $lang eq '' || ! -d $conf->getOption('SRCDIR')."/templates/summary/".$domain->getPref('summary_template')."/$lang") {
     $lang = 'en';
   }
   my $to = $email->getPref('summary_to');

--- a/lib/MailTemplate.pm
+++ b/lib/MailTemplate.pm
@@ -55,6 +55,13 @@ sub create {
   } else {
   	$lang = $language;
   }
+  # If user pref langage is not currently translated for the template type,
+  # use english by default
+  my $conf = ReadConfig::getInstance();
+  if (! -d $conf->getOption('SRCDIR')."/templates/$directory/$template/$lang") {
+        $lang = 'en';
+  }
+
   ## summary_type not yet available as user preference
   if ($type !~ /(html|text)/) {
     $type = 'html';
@@ -70,7 +77,6 @@ sub create {
   	  $from = $dm;
   	}
   }
-  my $conf = ReadConfig::getInstance();
   $path = $conf->getOption('SRCDIR')."/templates/$directory/$template/$lang/$filename";
  # print "testing path: $path\n";
   if (! -d $path."_parts" && ! -f $path.".txt") {


### PR DESCRIPTION
Sometimes, the user interface is translated but not the corresponding summary and vice-versa. Thus, we use english as the default summary language.