### PR TITLE
Fix matching of wwlists with empty values

### DIFF
--- a/bin/check_match_wwlists.pl
+++ b/bin/check_match_wwlists.pl
@@ -118,7 +118,7 @@ sub get_wlist_level {
 
 sub check_column_width {
     my $column_name = shift;
-    my $column_value = shift;
+    my $column_value = shift // "";
     my $columns_widths = shift;
     if (not exists($columns_widths->{$column_name})) {
         $columns_widths->{$column_name} = length($column_value);

--- a/lib/Email.pm
+++ b/lib/Email.pm
@@ -299,6 +299,9 @@ sub listMatch {
     $reg =~ s/\}/\\\}/g; # Escape }
     $reg =~ s/\?/\\\?/g; # Escape ?
     $reg =~ s/[^a-zA-Z0-9\+.\\\-_=@\*\$\^!#%&'\/\?`{|}~]//g; # Remove unwanted characters
+    if ( $reg eq "" ) {
+        $reg = '.*';
+    }
     if ($sender =~ /$reg/i) {
         return 1;
     }

--- a/lib/PrefTDaemon.pm
+++ b/lib/PrefTDaemon.pm
@@ -657,6 +657,9 @@ sub listMatch {
     $reg =~ s/\}/\\\}/g; # Escape }
     $reg =~ s/\?/\\\?/g; # Escape ?
     $reg =~ s/[^a-zA-Z0-9\+.\\\-_=@\*\$\^!#%&'\/\?`{|}~]//g; # Remove unwanted characters
+    if ( $reg eq "" ) {
+        $reg = '.*';
+    }
     if ($sender =~ /$reg/i) {
         return 1;
     }


### PR DESCRIPTION
When a wwlist was applied globally, the input email was tested against
an empty regex. The behaviour of such a test is to test the last
successful regex against the expression, making the test invalid.
To fix this, we replace any regex that would be empty to match anything.