### PR TITLE
Added clarification to filter adjustment message

### DIFF
--- a/www/user/htdocs/lang/en/texts.php
+++ b/www/user/htdocs/lang/en/texts.php
@@ -142,7 +142,7 @@ $txt['PURGESELECTEDSPAMS']      = "Manually purge the quarantine";
 $txt['HIDEFORCED']              = "Hide user-released messages"; //old
 $txt['FORCESPAM']               = "release the message"; //old
 $txt['ASKREASON']               = "display filtering rules";//old
-$txt['CONFSENDANALYSE']         = "A filter adjustment request will be sent to the MailCleaner Analysis Center; it includes a copy of the message that was wrongly blocked.";
+$txt['CONFSENDANALYSE']         = "A filter adjustment request will be sent to the MailCleaner Analysis Center; it includes a copy of the message that was wrongly blocked.</br>Note: A filter adjustment is not the same as whitelisting or blacklisting";
 $txt['AREYOUSURE']              = "<span class=\"question\">Are you sure you want this message to be analyzed and that filter adjustments may be applied?</span>";
 $txt['ASKANALYSE']              = "Filter adjustment request";
 $txt['PAGE']                    = "Page";


### PR DESCRIPTION
Some people think that sending a filter adjustment request would put the
sender in white or blacklist. Adding this message will clarify that it
does not.