### PR TITLE
Fix not being able to release attachement

### DIFF
--- a/bin/force_quarantined.pl
+++ b/bin/force_quarantined.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 #
 #   Mailcleaner - SMTP Antivirus/Antispam Gateway
 #   Copyright (C) 2004 Olivier Diserens <olivier@diserens.ch>
@@ -59,18 +59,40 @@ if (!open DHFILE, '>'.$config{VARDIR}."/spool/exim_stage4/input/".$id."-H") {
   die("CANNOTOPENDESTHEADERFILE");
 }
 my $id_header = '';
+my $hsize;
+my $hname;
+my $hlpart;
+my $hrpart;
+my $header;
+my $is_multiline_id = 0;
 while (<HFILE>) {
-   if (/^(\d+)I ([^:]+): <([^@]+)@([^>]+)>/) {
-     my $hsize = $1;
-     my $hname = $2;
-     my $hlpart = $3;
-     my $hrpart = $4;
+   if (/^(\d+)I (\S+):\s*<([^@]+)@([^>]+)>\s*$/m) {
+     # Do this if the Message ID is on a single line
+     $hsize = $1;
+     $hname = $2;
+     $hlpart = $3;
+     $hrpart = $4;
 
-     my $header = $hname.": <".$hlpart.$forced_postfix."@".$hrpart.">";
+     $header = $hname.": <".$hlpart.$forced_postfix."@".$hrpart.">";
      $id_header = sprintf('%.3d', length($header)+1)."I ".$header;
      print DHFILE $id_header."\n";
+   } elsif (/^(\d+)I (\S+):\s*$/) {
+     # Do this if the Message ID is on two lines
+     $is_multiline_id = 1;
+     $hsize = $1;
+     $hname = $2;
    } else {
-     print DHFILE $_;
+     if ($is_multiline_id && /^\s+<([^@]+)@([^>]+)>\s*$/){
+        # Do this if the Message ID is on two lines
+        $is_multiline_id = 0;
+        $hlpart = $1;
+        $hrpart = $2;
+        $header = $hname.": <".$hlpart.$forced_postfix."@".$hrpart.">";
+        my $id_header = sprintf('%.3d', length($header)+1)."I ".$header;
+        print DHFILE $id_header."\n";
+     } else {
+        print DHFILE $_;
+     }
    }
 }
 close HFILE;
@@ -86,7 +108,7 @@ foreach my $ext ( @exts ) {
   }
 }
 sleep 2;
-my $cmd = "/opt/exim4/bin/exim -C ".$config{SRCDIR}."/etc/exim/exim_stage4.conf -M ".$id." 2>&1"; 
+my $cmd = "/opt/exim4/bin/exim -C ".$config{SRCDIR}."/etc/exim/exim_stage4.conf -M ".$id." 2>&1";
 my $res = `$cmd`;
 if ($res =~ /^$/) {
 	print "FORCED\n";


### PR DESCRIPTION
When a mail is sent from an Exchange server, Exim registers the
Message-ID on two lines. When trying to resend the email to an other
Exchange server, this last on sees the same Message-ID, since it could
not be changed as in other messages, the ID being on two lines, and
drops the email as a DUPLICATEDELIVER.

When parsing the Headers file, the `force_quarantine.pl` script will
now look for multiple lines Message-IDs, set it on a single line and
adds a suffix to make sure the mail will be accepted by the distant
server.