### PR TITLE
Ensure no fetch during gitupdate

### DIFF
--- a/bin/fetch_autoconf.sh
+++ b/bin/fetch_autoconf.sh
@@ -52,7 +52,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -66,6 +66,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_autolearn.sh
+++ b/bin/fetch_autolearn.sh
@@ -69,6 +69,12 @@ ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
 fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
+fi
 
 . $SRCDIR/lib/updates/download_files.sh
 

--- a/bin/fetch_bayes.sh
+++ b/bin/fetch_bayes.sh
@@ -54,7 +54,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -75,6 +75,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_binary.sh
+++ b/bin/fetch_binary.sh
@@ -52,7 +52,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -67,6 +67,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_clamav.sh
+++ b/bin/fetch_clamav.sh
@@ -56,7 +56,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -71,6 +71,12 @@ ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
 fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
+fi
 
 . $SRCDIR/lib/updates/download_files.sh
 
@@ -78,7 +84,7 @@ ret=$(downloadDatas "$VARDIR/spool/clamav/" "clamav3" $randomize "clamav" "\|mai
 
 ## restart clamd daemon
 if [[ "$ret" -eq "1" ]]; then
-	kill -USR2 `cat $VARDIR/run/clamav/clamd.pid 2>/dev/null` > /dev/null 2>&1 
+	kill -USR2 `cat $VARDIR/run/clamav/clamd.pid 2>/dev/null` > /dev/null 2>&1
 	log "Database reloaded"
 fi
 

--- a/bin/fetch_clamspam.sh
+++ b/bin/fetch_clamspam.sh
@@ -55,7 +55,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -69,6 +69,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_databases.sh
+++ b/bin/fetch_databases.sh
@@ -52,7 +52,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -66,6 +66,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_magic.sh
+++ b/bin/fetch_magic.sh
@@ -53,7 +53,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -67,6 +67,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_newsl_rules.sh
+++ b/bin/fetch_newsl_rules.sh
@@ -53,7 +53,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -68,6 +68,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_rbls.sh
+++ b/bin/fetch_rbls.sh
@@ -53,7 +53,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -67,6 +67,13 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_spamc_rules.sh
+++ b/bin/fetch_spamc_rules.sh
@@ -54,7 +54,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -68,6 +68,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_updates.sh
+++ b/bin/fetch_updates.sh
@@ -52,7 +52,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -66,6 +66,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_watchdog_config.sh
+++ b/bin/fetch_watchdog_config.sh
@@ -53,7 +53,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -67,6 +67,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/bin/fetch_watchdog_modules.sh
+++ b/bin/fetch_watchdog_modules.sh
@@ -53,7 +53,7 @@ done
 
 CONFFILE=/etc/mailcleaner.conf
 SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
-if [ "$SRCDIR" = "" ]; then 
+if [ "$SRCDIR" = "" ]; then
   SRCDIR="/opt/mailcleaner"
 fi
 VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
@@ -67,6 +67,12 @@ FILE_NAME="${FILE_NAME%.*}"
 ret=$(createLockFile "$FILE_NAME")
 if [[ "$ret" -eq "1" ]]; then
         exit 0
+fi
+LOGFILE=${VARDIR}/log/mailcleaner/downloadDatas.log
+if [ "$(isGitupdateRunning)" -eq "1" ]; then
+    log "Gitupdate running, skipping ${FILE_NAME}"
+    removeLockFile "$FILE_NAME"
+    exit 0
 fi
 
 . $SRCDIR/lib/updates/download_files.sh

--- a/lib/lib_utils.sh
+++ b/lib/lib_utils.sh
@@ -50,6 +50,26 @@ function removeLockFile()
 	echo $?
 }
 
+function isLocked()
+{
+    process=$1
+    if [ -n "$(find ${LOCKFILEDIRECTORY} -type f -name "${process}")" ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+function hasFetchersRunning()
+{
+    echo $(isLocked "fetch_*")
+}
+
+function isGitupdateRunning()
+{
+    echo $(isLocked "gitupdate_running")
+}
+
 function slaveSynchronized()
 {
     slave_status=$(echo "SHOW SLAVE STATUS\G" | ${SRCDIR}/bin/mc_mysql -s)
@@ -70,4 +90,8 @@ function isMaster()
     else
         echo 0
     fi
+}
+
+function log {
+    echo "["`date "+%Y/%m/%d %H:%M:%S"`"] $1" >> $LOGFILE
 }

--- a/lib/updates/gitupdate.sh
+++ b/lib/updates/gitupdate.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
+CONFFILE=/etc/mailcleaner.conf
+SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
+if [ "$SRCDIR" = "" ]; then
+  SRCDIR="/usr/mailcleaner"
+fi
+
+source ${SRCDIR}/lib/lib_utils.sh
+
+# Prevent fetching data when the updater is running
+# If starts at the exact same time as the fetcher, there will be an issue with
+# the locking mechanism
+LOCKFILE_NAME="gitupdate_running"
+ret=$(createLockFile ${LOCKFILE_NAME})
+if [[ $ret != "0" ]]; then
+    echo "Could not create lockfile"
+    exit 1
+fi
+while [[ $(hasFetchersRunning) == 1 ]]; do
+    echo "Waiting for all fetchers to be stopped"
+    sleep 3
+done
+sleep 15
+
 git fetch
 git ls-files -d | xargs git checkout --
 
@@ -7,12 +30,12 @@ git ls-files -d | xargs git checkout --
 git stash save "MC:STASHORNOT"
 git pull
 git stash list |grep 'MC:STASHORNOT'
-[ $? == 1 ] && echo "NoChanges: Nothing to do" && exit 0
+[ $? == 1 ] && echo "NoChanges: Nothing to do" && removeLockFile ${LOCKFILE_NAME} && exit 0
 
 res=$(git stash pop | grep 'CONFLICT')
 retcod=$?
 resparsed=$(echo "$res" |sed -E "s/^CONFLICT.*in\s(.*)/\1/g")
-[ $retcod == 1 ] && echo "NoConflict: Nothing to do" && exit 0
+[ $retcod == 1 ] && echo "NoConflict: Nothing to do" && removeLockFile ${LOCKFILE_NAME} && exit 0
 
 OLDIFS=$IFS
 IFS=$'\n'
@@ -26,3 +49,5 @@ do
   git checkout HEAD -- $cffile
 done
 git stash drop
+
+removeLockFile ${LOCKFILE_NAME} && exit 0


### PR DESCRIPTION
If a file is fetched during the gitupdate, the stash will not succeed in
being popped, and all the local modifications will be lost.

With this, the updater will wait until all the fetchers are done to
update.

The fetchers will not start if the gitupdate is running

Todo:
- [ ] Ensure the updater is not waiting indefinitely in case of a remaining lockfile
- [ ] In create_lockfile, maybe check if the script is running in case the lockfile is still present