### PR TITLE
Extends LDAP Address Scope by Attributes used in UCS

### DIFF
--- a/www/classes/connector/fetcher/LDAPLookup.php
+++ b/www/classes/connector/fetcher/LDAPLookup.php
@@ -23,7 +23,7 @@
      * Definition of possible mail attributes
      * @var array
      */
-     protected $mail_attributes_ = array('mail', 'maildrop', 'mailAlternateAddress', 'mailalternateaddress', 'proxyaddresses', 'proxyAddresses', 'oldinternetaddress', 'oldInternetAddress', 'cn', 'userPrincipalName');
+     protected $mail_attributes_ = array('mail', 'maildrop', 'mailAlternateAddress', 'mailalternateaddress', 'proxyaddresses', 'proxyAddresses', 'oldinternetaddress', 'oldInternetAddress', 'cn', 'userPrincipalName', 'mailPrimaryAddress', 'mailAlternativeAddress');
     
     public function fetch($username, $domain) {
         $settings = $domain->getConnectorSettings();


### PR DESCRIPTION
Pull Request for issue #86 as requested. Allows MailCleaner to Authenticate against Univention Corporate Server LDAP directory, while fetching mail addresses correctly.