### PR TITLE
[Improvement] Remove domain statistics counts on domain deletion

### DIFF
--- a/www/guis/admin/application/models/Domain.php
+++ b/www/guis/admin/application/models/Domain.php
@@ -220,6 +220,13 @@ class Default_Model_Domain
 		}
 		$ret = $this->getMapper()->delete($this);
 		
+		// Check if this domains has stats (counts) and delete them
+                $counts_path = "/var/mailcleaner/spool/mailcleaner/counts/";
+                $domain_counts = $counts_path . trim($this->getParam('name'));
+                if (file_exists($domain_counts) && is_dir($domain_counts)) {
+                        exec('rm -rf '.escapeshellarg($domain_counts));
+                }
+
 		$params = array('what' => 'domains');
         $slave = new Default_Model_Slave();
         $res = $slave->sendSoapToAll('Service_silentDump', $params);


### PR DESCRIPTION
On large MailCleaner clusters, statistics counts took space (and especially inode). Clean automatically them when removing the domain.