### PR TITLE
Newsletter Whitelist Patch

### DIFF
--- a/lib/SpamHandler/Message.pm
+++ b/lib/SpamHandler/Message.pm
@@ -195,11 +195,11 @@ sub process {
 			$status = "is whitelisted ($whitelisted)";
 			$this->manageWhitelist($whitelisted);
 		}
-		elsif ((int($this->{sc_newsl}) >= 5) && (int($this->{sc_global}) == 0) && (int($email->getPref('allow_newsletters')))) {
+		elsif ((int($this->{sc_newsl}) >= 5) && (int($this->{sc_spamc}) < 5) && (int($email->getPref('allow_newsletters')))) {
 			$status = "is desired (Newsletter)";
 			$this->manageWhitelist(3);
 		}
-		elsif ((int($this->{sc_newsl}) >= 5) && (int($this->{sc_global}) == 0) && ($nwhitelisted)) {
+		elsif ((int($this->{sc_newsl}) >= 5) && (int($this->{sc_spamc}) < 5) && ($nwhitelisted)) {
 			$status = "is whitelisted by " . $res_wnews[$nwhitelisted] . " (Newsletter)";
 			$this->manageWhitelist(3);			
 		}


### PR DESCRIPTION
An immediate fix to honour newsletter whitelists except when SpamC is hit.

A further patch to properly handle whitelisting according to decisive modules will follow.