### PR TITLE
Correcting version variable on Status page

### DIFF
--- a/www/guis/admin/application/models/Slave.php
+++ b/www/guis/admin/application/models/Slave.php
@@ -294,7 +294,7 @@ class Default_Model_Slave
     }
 
     public function getHostVersion() {
-        return $this->getSNMPValue('MAILCLEANER-MIB::version'); 
+        return $this->getSNMPValue('MAILCLEANER-MIB::productVersion'); 
     }
 
     public function getHostPatchLevel() {


### PR DESCRIPTION
The revision to the MIB had changed the duplicate variable 'version' to 'productVersion'. The function to fetch the on the Status page version was not updated to match, so the page was generating errors.