### PR TITLE
Recognize 1 as true for active domains.

### DIFF
--- a/www/classes/system/SystemConfig.php
+++ b/www/classes/system/SystemConfig.php
@@ -219,7 +219,7 @@ class SystemConfig extends PrefHandler {
 
         $db_slaveconf = DM_SlaveConfig :: getInstance();
 
-        $query = "SELECT name FROM domain WHERE active='true' AND name != '__global__'";
+        $query = "SELECT name FROM domain WHERE (active='true' OR active=1) AND name != '__global__'";
         if (isset ($admin_) && $admin_->getPref('domains') != '*') {
             $query .= " AND (";
             foreach ($admin_->getDomains() as $dom) {


### PR DESCRIPTION
Same issue as PR 181 in a different place. Allows authenticated logins (and probably other functions) when the domain's active value is '1' instead of 'true'.