### PR TITLE
Forbid URIs matching predefined strings to contain a recipient domain

### DIFF
--- a/bin/fetch_spamc_modules_conf.sh
+++ b/bin/fetch_spamc_modules_conf.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#
+#   This script will fetch the actual spamassassin ruleset
+#
+#   Usage:
+#           fetch_spamc_modules_conf.sh [-r]
+
+usage()
+{
+  cat << EOF
+usage: $0 options
+
+This script will fetch the current ruleset
+
+OPTIONS:
+  -r   randomize start of the script, for automated process
+EOF
+}
+
+randomize=false
+
+while getopts ":r" OPTION
+do
+  case $OPTION in
+    r)
+       randomize=true
+       ;;
+    ?)
+       usage
+       exit
+       ;;
+  esac
+done
+
+CONFFILE=/etc/mailcleaner.conf
+SRCDIR=`grep 'SRCDIR' $CONFFILE | cut -d ' ' -f3`
+if [ "$SRCDIR" = "" ]; then 
+  SRCDIR="/opt/mailcleaner"
+fi
+VARDIR=`grep 'VARDIR' $CONFFILE | cut -d ' ' -f3`
+if [ "$VARDIR" = "" ]; then
+  VARDIR="/var/mailcleaner"
+fi
+
+. $SRCDIR/lib/lib_utils.sh
+FILE_NAME=$(basename -- "$0")
+FILE_NAME="${FILE_NAME%.*}"
+ret=$(createLockFile "$FILE_NAME")
+if [[ "$ret" -eq "1" ]]; then
+        exit 0
+fi
+
+. $SRCDIR/lib/updates/download_files.sh
+
+ret=$(downloadDatas "$SRCDIR/share/spamassassin/plugins/" "spamc_modules_conf" $randomize "null" "" "noexit")
+
+removeLockFile "$FILE_NAME"
+
+exit 0

--- a/lib/SpamC/UriTuning.pm
+++ b/lib/SpamC/UriTuning.pm
@@ -1,4 +1,3 @@
-Mail::SpamAssassin::Plugin::dbg("Botnet: checking IPINHOSTNAME");
 package UriTuning;
 
 use Mail::SpamAssassin::Plugin;

--- a/lib/SpamC/UriTuning.pm
+++ b/lib/SpamC/UriTuning.pm
@@ -1,3 +1,4 @@
+Mail::SpamAssassin::Plugin::dbg("Botnet: checking IPINHOSTNAME");
 package UriTuning;
 
 use Mail::SpamAssassin::Plugin;
@@ -17,7 +18,7 @@ sub new {
     
         # and return the new plugin object
         return $self;
-} 
+}
 
 sub _domain {
         my ($string) = @_;
@@ -26,8 +27,20 @@ sub _domain {
         return $1;
 }
 
+# Forbids the use of given strings in a URL that also contains the domain of a recipient
+# List of strings in /usr/mailcleaner/share/spamassassin/plugins/UriTuning.list
 sub gglapi_domain {
         my ($self, $permsgstatus, $body, $body_html) = @_;
+	my @elems;
+
+	# This module only runs if we have a file of domains to exclude
+	return 0 if ( ! -f '/usr/mailcleaner/share/spamassassin/plugins/UriTuning.list' );
+
+	# Get list of strings
+	open LIST, '<', '/usr/mailcleaner/share/spamassassin/plugins/UriTuning.list';
+	@elems = <LIST>;
+	close LIST;
+	chomp(@elems);
 
         # Recipient detection
         my $Recipients = lc( $permsgstatus->get('X-MailCleaner-recipients') );
@@ -38,18 +51,25 @@ sub gglapi_domain {
                 $Recip = _domain($Recip);
                 $AllRecipientsDomains{$Recip} = 1;
         }
+
         # URI detection
         my $uris = $permsgstatus->get_uri_detail_list ();
 
+	# For all URIs
         while (my($uri, $info) = each %{$uris}) {
-                if ( $uri =~ m/googleapis.com/ ) {
-                        foreach my $k (keys %AllRecipientsDomains) {
-                                if ($uri =~ m/\Q$k/) {
-                                        return 1;
-                                }
-                        }
+		# Check if it contains one of the strings
+		foreach my $elem (@elems) {
+	                if ( $uri =~ m/\Q$elem/ ) {
+				# Check if it contains one of the recipient s domain
+				foreach my $k (keys %AllRecipientsDomains) {
+                        	        if ($uri =~ m/\Q$k/) {
+                                	        return 1;
+	                                }
+        	                }
+			}
                 }
         }
 
+	# If we are here nothing was found
         return 0;
 }

--- a/share/spamassassin/70_uris.cf
+++ b/share/spamassassin/70_uris.cf
@@ -1,5 +1,0 @@
-loadplugin UriTuning /usr/mailcleaner/lib/SpamC/UriTuning.pm
-
-body MC_GOOGLEAPI_DOMAIN eval:gglapi_domain()
-describe MC_GOOGLEAPI_DOMAIN A link from googleapis.com is containing the domain name of a recipient
-score MC_GOOGLEAPI_DOMAIN 0.1


### PR DESCRIPTION
Forbid URIs matching predefined strings to contain a recipient domain