### PR TITLE
Link to same banner as default instead of directly to CE

### DIFF
--- a/templates/summary/owasp/en/summary_parts/banner.jpg
+++ b/templates/summary/owasp/en/summary_parts/banner.jpg
@@ -1,1 +1,1 @@
-/usr/mailcleaner/templates/summary/default/en/summary_parts/banner_ce.jpg
+/usr/mailcleaner/templates/summary/default/en/summary_parts/banner.jpg


### PR DESCRIPTION
Allows owasp template to correctly update the banner image whenever the default template changes (during registration).