### PR TITLE
Add shorthands to hostlist elements

### DIFF
--- a/bin/dns_lookup.pl
+++ b/bin/dns_lookup.pl
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#
+#   This script will output the count of messages/spams/viruses for a domain/user or globaly for a given period
+
+sub usage
+{
+	print "\nUsage: $0 [a|aaaa|mx|spf] domain <ip>\n
+  	a		query A record
+  	aaaa		query AAAA record
+  	mx		query MX record
+  	spf		query SPF record
+  	domain	the domain to query
+  	ip		(optional) check if given IP is in the list of results\n\n";
+	exit();
+	
+}
+
+use strict;
+use warnings;
+
+if ($0 =~ m/(\S*)\/\S+.pl$/) {
+  my $path = $1."/../lib";
+  unshift (@INC, $path);
+}
+require GetDNS;
+
+unless (defined($ARGV[1]) && $ARGV[0] =~ m/^(a|aaaa|mx|spf)$/i) {
+	usage();
+}
+
+my $dns = GetDNS->new();
+
+my ($target,$v);
+if (defined $ARGV[2]) {
+	$target = $ARGV[2];
+	unless ( $dns->{'validator'}->is_ipv4($ARGV[2])
+		|| $dns->{'validator'}->is_ipv6($ARGV[2]) ) 
+	{
+		print "\n'$target' is not a IPv4 or IPv6 address\n";
+		usage();
+	}
+}
+
+my @ips;
+if ($ARGV[0] eq 'a' || $ARGV[0] eq 'A') {
+	@ips = $dns->getA($ARGV[1]);
+} elsif ($ARGV[0] eq 'aaaa' || $ARGV[0] eq 'AAAA') {
+	@ips = $dns->getAAAA($ARGV[1]);
+} elsif ($ARGV[0] eq 'mx' || $ARGV[0] eq 'MX') {
+	@ips = $dns->getMX($ARGV[1]);
+} elsif ($ARGV[0] eq 'spf' || $ARGV[0] eq 'SPF') {
+	@ips = $dns->getSPF($ARGV[1]);
+} else {
+	die "Invalid record type\n";
+}
+
+if ($target) {
+	print $dns->inIPList($target,@ips) . "\n";
+} else {
+	foreach (@ips) {
+		print("$_\n");
+	}
+}

--- a/bin/dump_exim_config.pl
+++ b/bin/dump_exim_config.pl
@@ -2,6 +2,7 @@
 #
 #   Mailcleaner - SMTP Antivirus/Antispam Gateway
 #   Copyright (C) 2004 Olivier Diserens <olivier@diserens.ch>
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -39,6 +40,7 @@ if ($0 =~ m/(\S*)\/\S+.pl$/) {
 }
 require ConfigTemplate;
 require MCDnsLists;
+require GetDNS;
 require DB;
 
 my $DEBUG = 1;
@@ -515,13 +517,11 @@ sub get_system_config
      }
     $sconfig{'__TRUSTED_HOSTS__'} = '';
     if ($row{'trusted_ips'}) {
-    	$sconfig{'__TRUSTED_HOSTS__'} = $row{'trusted_ips'};
-    	$sconfig{'__TRUSTED_HOSTS__'} =~ s/\s+/ ; /g;
+        $sconfig{'__TRUSTED_HOSTS__'} = join(' ; ', expand_host_string($row{'trusted_ips'}));
     }
     $sconfig{'__HTML_CTRL_WL_HOSTS__'} = '';
     if ($row{'html_wl_ips'}) {
-        $sconfig{'__HTML_CTRL_WL_HOSTS__'} = $row{'html_wl_ips'};
-        $sconfig{'__HTML_CTRL_WL_HOSTS__'} =~ s/\s+/ ; /g;
+        $sconfig{'__HTML_CTRL_WL_HOSTS__'} = join(' ; ', expand_host_string($row{'html_wl_ips'}));
     }
     $sconfig{'__TAGMODEBYPASSWHITELISTS__'} = $row{'tag_mode_bypass_whitelist'};
     $sconfig{'__WHITELISTBOTHFROM__'} = $row{'whitelist_both_from'};
@@ -714,12 +714,10 @@ sub get_exim_config{
 	$config{'__RECEIVED_HEADER_TEXT__'} = $row{'header_txt'};
 	$config{'__RELAY_FROM_HOSTS__'} = $row{'relay_from_hosts'};
         if ($config{'__RELAY_FROM_HOSTS__'}) {
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\s\:\s/ ; /g;
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\r\n/ ; /g;
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\n/ ; /g;
+          $config{'__RELAY_FROM_HOSTS__'} = join(' ; ',expand_host_string($config{'__RELAY_FROM_HOSTS__'}));
         }
     if (defined( $row{'no_ratelimit_hosts'}) && $row{'no_ratelimit_hosts'} ne '' ) {
-          $config{'__NO_RATELIMIT_HOSTS__'} = $m_infos{'host'}." ; ".$row{'no_ratelimit_hosts'};
+          $config{'__NO_RATELIMIT_HOSTS__'} = $m_infos{'host'}." ; ".join(' ; ',expand_host_string($row{'no_ratelimit_hosts'}));
     } else {
          $config{'__NO_RATELIMIT_HOSTS__'} = $m_infos{'host'};
     }
@@ -727,9 +725,7 @@ sub get_exim_config{
         $config{'__RELAY_FROM_HOSTS__'} = '';
     }
     if ($config{'__NO_RATELIMIT_HOSTS__'}) {
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\s\:\s/ ; /g;
-          $config{'__NO_RATELIMIT_HOSTS__'} =~ s/\r\n/ ; /g;
-          $config{'__NO_RATELIMIT_HOSTS__'} =~ s/\n/ ; /g;
+          $config{'__NO_RATELIMIT_HOSTS__'} = join(' ; ',expand_host_string($config{'__SMTP_CONN_ACCESS__'}));
     }
     if (defined( $row{'hosts_require_tls'}) ) {
           $config{'__HOSTS_REQUIRE_TLS__'} = $row{'hosts_require_tls'};
@@ -737,9 +733,7 @@ sub get_exim_config{
     	 $config{'__HOSTS_REQUIRE_TLS__'} = '';
     }
     if ($config{'__HOSTS_REQUIRE_TLS__'}) {
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\s\:\s/ ; /g;
-          $config{'__HOSTS_REQUIRE_TLS__'} =~ s/\r\n/ ; /g;
-          $config{'__HOSTS_REQUIRE_TLS__'} =~ s/\n/ ; /g;
+          $config{'__HOSTS_REQUIRE_TLS__'} = join(' ; ',expand_host_string($config{'__SMTP_CONN_ACCESS__'}));
     }
 
     if (defined( $row{'hosts_require_incoming_tls'}) ) {
@@ -748,7 +742,6 @@ sub get_exim_config{
          $config{'__HOSTS_REQUIRE_INCOMING_TLS__'} = '';
     }
     if ($config{'__HOSTS_REQUIRE_INCOMING_TLS__'}) {
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\s\:\s/ ; /g;
           $config{'__HOSTS_REQUIRE_INCOMING_TLS__'} =~ s/\r\n/ ; /g;
           $config{'__HOSTS_REQUIRE_INCOMING_TLS__'} =~ s/\n/ ; /g;
     }
@@ -771,9 +764,7 @@ sub get_exim_config{
 
 	$config{'__SMTP_CONN_ACCESS__'} = $row{'smtp_conn_access'};
         if ($config{'__SMTP_CONN_ACCESS__'}) {
-          $config{'__RELAY_FROM_HOSTS__'} =~ s/\s\:\s/ ; /g;
-          $config{'__SMTP_CONN_ACCESS__'} =~ s/\r\n/ ; /g;
-          $config{'__SMTP_CONN_ACCESS__'} =~ s/\n/ ; /g;
+          $config{'__SMTP_CONN_ACCESS__'} = join(' ; ',expand_host_string($config{'__SMTP_CONN_ACCESS__'}));
         }
 	$config{'__MAX_RCPT__'} = $row{'max_rcpt'};
 	$config{'__MAX_RECEIVED__'} = $row{'received_headers_max'};
@@ -903,12 +894,14 @@ sub dump_ignore_list  {
 
    my $file = $tmpdir.'/'.$filename;
 
+   my @list = expand_host_string($ignorehosts);
    if (open(RBLFILE, ">$file")) {
-
-       foreach my $host (split("\n", $ignorehosts)) {
+       foreach my $host (@list) {
            print RBLFILE $host."\n";
        }
        close RBLFILE;
+   } else {
+       print STDERR "Failed to open $file\n";
    }
 }
 
@@ -926,7 +919,7 @@ sub dump_blacklists {
      if (open(FILE, ">$filepath")) {
          if ($incoming_config{$file}) {
            if ($file =~ /host_reject/) {
-              foreach my $host (split(/[\n\s;]/, $incoming_config{$file})) {
+              foreach my $host (expand_host_string($incoming_config{$file})) {
                  print FILE $host."\n";
               }
            } else {
@@ -936,6 +929,8 @@ sub dump_blacklists {
            }
          }
          close FILE;
+      } else {
+         print STDERR "Failed to open $filepath: $!\n";
       }
    }
 }
@@ -1000,6 +995,7 @@ sub print_ip_domain_rule {
 	    	open $FH_IP_DOM, '>>', $conf->getOption('VARDIR') . "/spool/tmp/exim_stage1/spamcwhitelists/$domain";
 	}
 
+	$sender_list = join(' ; ', expand_host_string($sender_list));
 	if ($type eq 'spam-ip-dom') {
 		$smtp_rule = <<"END";
 warn    hosts         = <; $sender_list
@@ -1149,4 +1145,11 @@ sub is_ipv6_disabled
     } else {
         return 0
     }
+}
+
+sub expand_host_string
+{
+    my $string = shift;
+    my $dns = GetDNS->new();
+    return $dns->dumper($string);
 }

--- a/lib/GetDNS.pm
+++ b/lib/GetDNS.pm
@@ -1,0 +1,322 @@
+package GetDNS;
+
+use strict;
+use warnings;
+use Net::DNS;
+use Data::Validate::IP;
+
+sub new
+{
+	my $resolver = Net::DNS::Resolver->new;
+	my $validator = Data::Validate::IP->new;
+
+	my $self = {
+		'resolver' => $resolver,
+		'validator' => $validator,
+		'recursion' => 1
+	};
+	bless $self;
+
+	return $self;
+}
+
+sub dumper {
+	my $self = shift;
+	my $raw = shift;
+
+	unless (defined($raw)) {
+		return ();
+	}
+
+	# Disabling recursion in order to utilize caching
+	my $recursion = $self->{recursion};
+	$self->{recursion} = 0;
+
+	chomp($raw);
+	$raw =~ s/([\s\n\r;])+/ /g;
+
+	my %cache;
+	my @list;
+	foreach my $line (split(" ", $raw)) {
+		# Some fields allow for a hostname which should not be resolved to IPs
+		# Push without looking up DNS info
+		if ($line =~ m/^([a-z0-9\-*]+\.)+[a-z]*$/) {
+			push(@list,$line);
+		} else {
+			$cache{$line} = undef;
+		}
+	}
+
+	my $continue;
+	do {
+		foreach my $item (keys %cache) {
+			if ($item eq '*' || $item eq '0.0.0.0/0') {
+				$self->{recursion} = $recursion;
+				return ( '0.0.0.0/0' );
+			} elsif (defined($cache{$item})) {
+				next;
+			} elsif ($item =~ m#/\d+$#) {
+				$cache{$item} = $item;
+			} elsif ($self->validIP4($item)) {
+				$cache{$item} = $item.'/32';
+			} elsif ($self->validIP6($item)) {
+				$cache{$item} = $item.'/128';
+			} elsif ($item =~ m#/a$#i) {
+				unless(defined($cache{$item})) {
+					my $a = $item;
+					$a =~ s#/a$##i;
+					foreach ($self->getA($a)) {
+						unless (defined($cache{$_})) {
+							$cache{$_} = undef;
+						}
+					}
+					$cache{$item} = 'cached';
+				}
+			} elsif ($item =~ m#/aaaa$#i) {
+				unless(defined($cache{$item})) {
+					my $aaaa = $item;
+					$aaaa =~ s#/aaaa$##i;
+					foreach ($self->getAAAA($aaaa)) {
+						unless (defined($cache{$_})) {
+							$cache{$_} = undef;
+						}
+					}
+					$cache{$item} = 'cached';
+				}
+			} elsif ($item =~ m#/mx$#i) {
+				unless(defined($cache{$item})) {
+					my $mx = $item;
+					$mx =~ s#/mx$##i;
+					foreach ($self->getMX($mx)) {
+						unless (defined($cache{$_})) {
+							$cache{$_} = undef;
+						}
+					}
+					$cache{$item} = 'cached';
+				}
+			} elsif ($item =~ m#/spf$#i) {
+				unless(defined($cache{$item})) {
+					my $spf = $item;
+					$spf =~ s#/spf$##i;
+					my @records = $self->getSPF($spf);
+					foreach (@records) {
+						unless (defined($cache{$_})) {
+							$cache{$_} = undef;
+						}
+					}
+					$cache{$item} = 'cached';
+				}
+			}
+		}
+
+		$continue = 0;
+		foreach my $key (keys %cache) {
+			unless (defined($cache{$key})) {
+				$continue = 1;
+			}
+		}
+	} while ($continue);
+
+	foreach (keys %cache) {
+		if ($cache{$_} eq 'cached') {
+			next;
+		} else {
+			push(@list,$cache{$_});
+		}
+	}
+			
+	$self->{recursion} = $recursion;
+	return $self->uniq(@list);
+}
+			
+sub getA
+{
+	my $self = shift;
+	my $target = shift;
+	
+	my $res = $self->{'resolver'}->query($target, 'A');
+	if ($res) {
+		return ($res->answer)[0]->address;
+	}
+
+	return ();
+}
+
+sub getAAAA
+{
+	my $self = shift;
+	my $target = shift;
+	
+	my $res = $self->{'resolver'}->query($target, 'AAAA');
+	if ($res) {
+		return ($res->answer)[0]->address;
+	}
+
+	return ();
+}
+
+sub getMX
+{
+	my $self = shift;
+	my $target = shift;
+	my @res  = mx($self->{'resolver'}, $target);
+
+	my @ips = ();
+	if (@res) {
+		if ($self->{'recursion'}) {
+			foreach (@res) {
+				@ips = (
+					@ips,
+					$self->getA($_->exchange),
+					$self->getAAAA($_->exchange)
+				);
+			}
+		} else {
+			foreach (@res) {
+				push(@ips,$_->exchange.'/a');
+				push(@ips,$_->exchange.'/aaaa');
+			}
+		}
+	}
+
+	return $self->uniq(@ips);
+}
+
+sub getSPF
+{
+	my $self = shift;
+	my $target = shift;
+	my $res  = $self->{'resolver'}->query($target, 'TXT');
+
+	unless ($res) {
+		return ();
+	}
+
+	my @blocks;
+	foreach ($res->answer) {
+		if ($_->{'txtdata'}->[0]->[0] =~ /^v=spf/) {
+			@blocks = split(' ', $_->{'txtdata'}->[0]->[0]);
+			last;
+		}
+	}
+
+	my @ips;
+	foreach (@blocks) {
+		if ($_ =~ m/^[\?\-\~]/) {
+			next;
+		} elsif ($_ =~ /\+?(v=spf.|all|ptr|exists)$/i) {
+			next;
+		} elsif ($_ =~ /^([+\-\?])?a$/i) {
+			if ($self->{'recursion'}) {
+				push(@ips,$self->getA($target));
+			} else {
+				push(@ips,$target.'/a');
+			}
+		} elsif ($_ =~ /^([+\-\?])?aaaa?$/i) {
+			if ($self->{'recursion'}) {
+				push(@ips,$self->getAAAA($target));
+			} else {
+				push(@ips,$target.'/aaaa');
+			}
+		} elsif ($_ =~ /^([+\-\?])?mx$/i) {
+			if ($self->{'recursion'}) {
+				push(@ips,$self->getMX($target));
+			} else {
+				push(@ips,$target.'/mx');
+			}
+		} elsif ($_ =~ /([+\-\?])?ip[46]:/i) {
+			my ($type, @ip) = split(':',$_);
+			push(@ips,join(':',@ip));
+		} elsif ($_ =~ /([+\-\?])?include:/i) {
+			my ($tmp, $include) = split(':',$_);
+			if ($self->{'recursion'}) {
+				push(@ips,$self->getSPF($include));
+			} else {
+				push(@ips,$include.'/spf');
+			}
+		} elsif ($_ =~ /([+\-\?])?redirect=/i) {
+			my ($tmp, $redirect) = split('=',$_);
+			if ($self->{'recursion'}) {
+				push(@ips,$self->getSPF($redirect));
+			} else {
+				push(@ips,$redirect.'/spf');
+			}
+		} else {
+			print("Unrecognized pattern $_\n");
+		}
+	}
+
+	return $self->uniq(@ips);
+}
+
+sub validIP4
+{
+	my $self = shift;
+	my $target = shift;
+	
+	return $self->{'validator'}->is_ipv4($target);
+}
+
+sub validIP6
+{
+	my $self = shift;
+	my $target = shift;
+	
+	return $self->{'validator'}->is_ipv6($target);
+}
+
+sub inIPList
+{
+	my $self = shift;
+	my $target = shift;
+	my @ips = @_;
+
+	my $version;
+	if ($self->{'validator'}->is_ipv4($target)) {
+		foreach my $range (@ips) {
+			unless ($self->{'validator'}->is_ipv4((split('/',$range))[0])) {
+				next;
+			}
+			unless ($range =~ m#/\d+$#) {
+				$range .= '/32';
+			}
+			if ($self->{'validator'}->is_innet_ipv4($target,$range)) {
+				return 1;
+			}
+		}
+	} elsif ($self->{'validator'}->is_ipv6($target)) {
+		foreach my $range (@ips) {
+			unless ($self->{'validator'}->is_ipv6((split('/',$range))[0])) {
+				next;
+			}
+			unless ($range =~ m#/\d+$#) {
+				$range .= '/128';
+			}
+			if ($self->{'validator'}->is_innet_ipv4($target,$range)) {
+				return 1;
+			}
+		}
+	} else {
+		die "Invalid IP $target\n";
+	}
+	return 0;
+}
+
+sub uniq
+{
+	my $self = shift;
+	my @ips = @_;
+	
+	my %ips;
+	foreach (@ips) {
+		$ips{$_} = 1;
+	}
+
+	my @uniq;
+	foreach (keys %ips) {
+		push(@uniq, $_);
+	}
+
+	return @uniq
+}
+1;

--- a/www/guis/admin/application/library/Validate/HostList.php
+++ b/www/guis/admin/application/library/Validate/HostList.php
@@ -39,6 +39,8 @@ class Validate_HostList extends Zend_Validate_Abstract
         $hosts = preg_split('/[,\s]+/', $value);
         foreach ($hosts as $host) {
           $host = preg_replace('/\/\d+/', '', $host);
+          $host = preg_replace('/(.*)\/(a|A|aaaa|AAAA|mx|MX)$/', '\1', $host);
+          $host = preg_replace('/(_)*(.*)\/(spf|spf)$/', '\2', $host);
           if (! $validator->isValid($host)) {
           	  $this->host = $host;
           	  $this->_error(self::MSG_BADHOST);

--- a/www/guis/admin/application/library/Validate/IpList.php
+++ b/www/guis/admin/application/library/Validate/IpList.php
@@ -36,7 +36,9 @@ class Validate_IpList extends Zend_Validate_Abstract
         $addresses = preg_split('/[,\s]+/', $value);
         foreach ($addresses as $address) {
           $address = preg_replace('/\/\d+$/', '', $address);
-          if (! $validator->isValid($address)) {
+          if (preg_match('/\/(a|A|aaaa|AAAA|mx|MX|spf|SPF)$/', $address)) {
+		next;
+          } elseif (! $validator->isValid($address)) {
           	  $this->ip = $address;
           	  $this->_error(self::MSG_BADIP);
               return false;

--- a/www/guis/admin/application/library/Validate/SMTPHostList.php
+++ b/www/guis/admin/application/library/Validate/SMTPHostList.php
@@ -42,7 +42,8 @@ class Validate_SMTPHostList extends Zend_Validate_Abstract
               $host = preg_replace('/::?\d+/', '', $host);
           }
           $host = preg_replace('/\/\d{1,2}/', '', $host);
-          $host = preg_replace('/\/(mx|MX)/', '', $host);
+          $host = preg_replace('/\/(a|A|aaaa|AAAA|mx|MX)$/', '', $host);
+          $host = preg_replace('/(_)*(.*)\/(spf|SPF)$/', '\2', $host);
           $host = preg_replace('/\*/', '', $host);
           $host = preg_replace('/^\./', '', $host);
           if (! $validator->isValid($host)) {


### PR DESCRIPTION
Provides expansion of DNS records to lists of IP blocks for A, AAAA, MX, and SPF (pass), using a suffix with /type

eg. adding _spf.google.com/spf to a trusted ip list will expand to all IPs in the SPF record when the config file is dumped

Also provides a script (bin/dns_lookup.pl) for testing, easy SPF validation, etc.

Also standardizes the dumpers, fixes a couple of bugs related to '/mx' being a pre-existing shorthand with no functionality and IPv6 support in SNMP.