### PR TITLE
Add NTPD to new Init system

### DIFF
--- a/etc/init.d/ntpd
+++ b/etc/init.d/ntpd
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#
+#   /etc/init.d/ntpd: service management for Network Time Protocol Daemon
+
+use strict;
+use warnings;
+
+use lib '/usr/mailcleaner/lib';
+use ManageServices;
+
+our $service = 'ntpd';
+
+my $manager = ManageServices->new( 'autoStart' => 0 ) || die "Failed to create object: $!\n";
+$manager->loadModule($service) || die "Could not load module for service: $service\n";
+
+unless (scalar(@ARGV) && defined($manager->{'module'}->{'actions'}->{$ARGV[0]})) {
+	print "\nusage: $0 <action>\n\n";
+	$manager->usage($service);
+	exit();
+}
+
+my $action = shift;
+
+my $status = $manager->{'module'}->{'actions'}->{$action}->{'cmd'}($manager);
+
+if (defined($status) ) {
+	print $manager->{'services'}->{$service}->{'name'} . ': ';
+	if ($status =~ m/^\-?\d$/) {
+		print $manager->{'codes'}->{$status}->{'verbose'} . "\n";
+	} else {
+		print $status . "\n";
+	}
+} 

--- a/lib/ManageServices/NTPD.pm
+++ b/lib/ManageServices/NTPD.pm
@@ -18,7 +18,7 @@
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-package ManageServices::ClamSpamD;
+package ManageServices::NTPD;
 
 use strict;
 use warnings;
@@ -30,7 +30,7 @@ sub init
 	my $module = shift;
 	my $class = shift;
 	my $self = $class->SUPER::createModule( config($class) );
-	bless $self, 'ManageServices::ClamSpamD';
+	bless $self, 'ManageServices::NTPD';
 
 	return $self;
 }
@@ -40,25 +40,19 @@ sub config
 	my $class = shift;
 
 	my $config = {
-		'name' 		=> 'clamspamd',
-		'cmndline'	=> 'clamav/clamspamd.conf',
-		'cmd'		=> '/opt/clamav/sbin/clamd',
-		'conffile'	=> $class->{'conf'}->getOption('SRCDIR').'/etc/clamav/clamspamd.conf',
-		'pidfile'	=> $class->{'conf'}->getOption('VARDIR').'/run/clamspamd.pid',
-		'logfile'	=> $class->{'conf'}->getOption('VARDIR').'/log/clamav/clamspamd.log',
-		'localsocket'	=> $class->{'conf'}->getOption('VARDIR').'/run/clamav/clamspamd.sock',
-		'children'	=> 1,
-		'user'		=> 'clamav',
-		'group'		=> 'clamav',
-		'daemonize'	=> 'yes',
+		'name' 		=> 'ntpd',
+		'cmndline'	=> '/usr/sbin/ntpd',
+		'cmd'		=> '/usr/sbin/ntpd',
+		'pidfile'	=> '/var/run/ntpd.pid',
+		'user'		=> 'ntp',
+		'group'		=> 'ntp',
+		'daemonize'	=> 'no',
 		'forks'		=> 0,
-		'nouserconfig'  => 'yes',
-		'syslog_facility' => '',
+		'syslog_facility' => 'local1',
 		'debug'		=> 0,
 		'log_sets'	=> 'all',
 		'loglevel'	=> 'info',
 		'timeout'	=> 5,
-		'checktimer'	=> 10,
 		'actions'	=> {},
 	};
 	
@@ -69,8 +63,11 @@ sub setup
 {
 	my $self = shift;
 	my $class = shift;
-	
-	return 0;
+
+	$self->{'cmd'} .= ' -p ' . $self->{'pidfile'} . ' -g -u ' .
+		$self->{'uid'} . ':' . $self->{'gid'};
+
+	return 1;
 }
 
 sub preFork
@@ -87,10 +84,9 @@ sub mainLoop
 	my $class = shift;
 	
 	my $cmd = $self->{'cmd'};
-	$cmd .= ' --config-file=' . $self->{'conffile'};
 	$self->doLog("Running $cmd", 'daemon');
-	system($cmd);
-	
+	system("$cmd");
+
 	return 1;
 }
 


### PR DESCRIPTION
Will include it in regular checks and restart if necessay.
Merges previous commit to ignore defunct processes in containerized installations.
Also remove the unnecessary dumping of config files in ClamSpamD which were erroneously copied from SpamD.