### PR TITLE
Add infobox for system watchdogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,13 +65,19 @@ Session.vim
 # auto-generated tag files
 tags
 
-bin/watchdog/
-etc/watchdog/
+bin/watchdog/EE_mod*
+bin/watchdog/CUSTOM_mod*
+bin/watchdog/files.filter
+etc/watchdog/EE_mod*
+etc/watchdog/CUSTOM_mod*
+etc/watchdog/files.filter
+www/guis/admin/public/downloads/watchdogs.html
 etc/rbls/
 share/newsld/siteconfig/
 share/spamassassin/
 etc/autoconf/
 etc/exim/mc_binary/
 updates/
+etc/mailcleaner/version.def
 
 # End of https://www.gitignore.io/api/emacs,vim

--- a/bin/unregister_mailcleaner.sh
+++ b/bin/unregister_mailcleaner.sh
@@ -192,8 +192,8 @@ if [ "$REGISTERED" = "1" ];then
 	rm -rf $SRCDIR/share/newsld/siteconfig/* >/dev/null 2>&1
 	rm -rf $SRCDIR/etc/exim/mc_binary/* >/dev/null 2>&1
 	rm -rf $SRCDIR/etc/rbls/* >/dev/null 2>&1
-	rm -rf $SRCDIR/bin/watchdog/MC_* >/dev/null 2>&1
-	rm -rf $SRCDIR/etc/watchdog/MC_* >/dev/null 2>&1
+	rm -rf $SRCDIR/bin/watchdog/EE_* >/dev/null 2>&1
+	rm -rf $SRCDIR/etc/watchdog/EE_* >/dev/null 2>&1
 	rm -rf $SRCDIR/bin/watchdog/dbs.md5 >/dev/null 2>&1
 	rm -rf $SRCDIR/etc/watchdog/dbs.md5 >/dev/null 2>&1
 	rm -rf $SRCDIR/updates/* >/dev/null 2>&1

--- a/bin/watchdog/MC_fix_pid_files.sh
+++ b/bin/watchdog/MC_fix_pid_files.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+find /var/mailcleaner/run/watchdog/ -type f -mmin +2 -delete
+exit 0

--- a/bin/watchdog/MC_mod_Internal_keys.sh
+++ b/bin/watchdog/MC_mod_Internal_keys.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+#if [[ $(grep mailcleaner-internal /root/.ssh/authorized_keys | wc -l) > 2 ]]
+RET=$(grep "internal" /root/.ssh/authorized_keys |wc -l)
+if (( "$RET" > "1" ))
+then
+    echo "Internal keys found several times in /root/.ssh/authorized_keys" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+if (( "$RET" <= "0" ))
+then
+    echo "Internal keys not found in /root/.ssh/authorized_keys" > $OUT_FILE
+    my_own_exit "2"
+fi
+
+if [ ! -f /root/.ssh/id_rsa_internal ]
+then
+    echo "/root/.ssh/id_rsa_internal not found" > $OUT_FILE
+    my_own_exit "3"
+fi
+
+if [ ! -f /root/.ssh/id_rsa_internal.pub ]
+then
+    echo "/root/.ssh/id_rsa_internal.pub not found" > $OUT_FILE
+    my_own_exit "4"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_SKELETON.pl
+++ b/bin/watchdog/MC_mod_SKELETON.pl
@@ -1,0 +1,48 @@
+#!/usr/bin/perl -w
+use strict;
+use File::Basename;
+
+# Récupération du nom du script
+my $script_name         = basename($0);
+my $script_name_no_ext  = $script_name;
+$script_name_no_ext     =~ s/\.[^.]*$//;
+
+# Timestamp => fichier unique et temps d'exécution
+my $timestamp           = time();
+
+# Fichier PID et pour écrire le résultat 
+my $PID_FILE   = '/var/mailcleaner/run/watchdog/' . $script_name_no_ext . '.pid';
+my $OUT_FILE   = '/var/mailcleaner/spool/watchdog/' .$script_name_no_ext. '_' .$timestamp. '.out';
+
+open my $file, '>', $OUT_FILE;
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+sub my_own_exit {
+    my ($exit_code) = @_;
+    $exit_code = 0  if ( ! defined ($exit_code) );
+
+    if ( -e $PID_FILE ) {
+        unlink $PID_FILE;
+    }
+
+    my $ELAPSED = time() - $timestamp;
+    print $file "EXEC : $ELAPSED\n";
+    print $file "RC : $exit_code\n";
+
+    close $file;
+
+    exit($exit_code);
+}
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+
+
+
+
+
+# A CONSERVER !
+my_own_exit(0);

--- a/bin/watchdog/MC_mod_SKELETON.sh
+++ b/bin/watchdog/MC_mod_SKELETON.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+
+
+
+
+
+# A CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_Updater_Status.sh
+++ b/bin/watchdog/MC_mod_Updater_Status.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+# If file doesn't exist, things are fine
+STATUSFILE=/var/mailcleaner/spool/mailcleaner/updater4mc.status
+if [ -e $STATUSFILE ]; then
+    STATUS="`cat $STATUSFILE`"
+    # If running for longer than an hour or exited without cleaning
+    if [[ $STATUS == "Running" ]]; then
+        if [ "$(expr $(stat -c %Y $STATUSFILE) + 3600)" -lt "$(date +%s)" ]; then
+            echo "Updater4MC still running after 1 hour or exited without completing" >> $OUT_FILE
+            my_own_exit "1"
+        fi
+    # If it specifically failed an update
+    elif grep -q "^Failed " <<< `echo "$STATUS"`; then
+        my_own_exit "2"
+    # Misc error code to accomadate future errors
+    elif grep -q "Not a valid MailCleaner Installation: no conf file" <<< `echo "$STATUS"`; then
+        my_own_exit "3"
+    else
+        echo "Updater4MC encountered error: $STATUS" >> $OUT_FILE
+        my_own_exit "255"
+    fi
+fi
+
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_Updater_TLS.sh
+++ b/bin/watchdog/MC_mod_Updater_TLS.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [ -f /root/Updater4MC/updater_$(date +%Y-%m-%d).log ]; then
+    log_file="/root/Updater4MC/updater_$(date +%Y-%m-%d).log"
+else
+    log_file="/root/Updater4MC/updater_$(date +%Y-%m-%d -d yesterday).log"
+fi
+
+if [[ $(grep "gnutls_handshake" `ls -Art $log_file | tail -n 1` | wc -l) > 0 ]]
+then
+    echo "Bad handshake for Updater4MC.sh" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_bad_dumper.sh
+++ b/bin/watchdog/MC_mod_bad_dumper.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+LOG_FILE="/var/mailcleaner/log/mailcleaner/dumper.log"
+LOG_MOD=`stat --format=%Y $LOG_FILE`
+NB_INVALID=`grep "Did not understand hostlist entries " $LOG_FILE | wc -l`
+# Le jour dernier
+if [[ $LOG_MOD -gt $((timestamp-86400)) ]]; then
+    if [[ $NB_INVALID -ne 0 ]]; then
+        echo "Invalid hostlist items. See $LOG_FILE" > $OUT_FILE
+        my_own_exit "1"
+    fi
+fi
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_F2B.sh
+++ b/bin/watchdog/MC_mod_detect_F2B.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+NB_PROCESS=`ps fauxw |grep fail2ban-server |grep -v 'grep '|grep -v 'MC_mod_'|wc -l`
+#if [[ $NB_PROCESS -ne 1 ]]; then
+if [[ $NB_PROCESS -eq 1 ]]; then
+    echo "fail2ban-server is running" > $OUT_FILE
+#    echo "fail2ban-server is not running (or has too many processes)" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_PrefTDaemon.sh
+++ b/bin/watchdog/MC_mod_detect_PrefTDaemon.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [[ $(ps fauxw |grep PrefTDaemon |grep -v 'grep '|grep -v 'MC_mod_'|wc -l) > 1 ]]
+then
+    echo "Too many PrefTDaemon processes detected" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_Spam_Handler.sh
+++ b/bin/watchdog/MC_mod_detect_Spam_Handler.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [[ $(ps fauxw |grep SpamHandler |grep -v 'grep '|grep -v 'MC_mod_'|wc -l) > 1 ]]
+then
+    echo "Too many SpamHandler processes detected" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_StatsDaemon.sh
+++ b/bin/watchdog/MC_mod_detect_StatsDaemon.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [[ $(ps fauxw |grep StatsDaemon |grep -v 'grep '|grep -v 'MC_mod_'|wc -l) > 1 ]]
+then
+    echo "Too many StatsDaemon processes detected" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_Summaries.sh
+++ b/bin/watchdog/MC_mod_detect_Summaries.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+NB_PROCESS=`grep "MySQL server has gone away" /var/mailcleaner/log/mailcleaner/summaries.log.0 | wc -l`
+#if [[ $NB_PROCESS -ne 1 ]]; then
+if [[ $NB_PROCESS -ne 0 ]]; then
+    echo "Error in summaries" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_bad_git.sh
+++ b/bin/watchdog/MC_mod_detect_bad_git.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [[ $(grep ' is corrupt' /var/mailcleaner/log/mailcleaner/updater4mc.log | wc -l) > 1 ]]
+then
+    echo "Git encountered a corruption error" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"
+

--- a/bin/watchdog/MC_mod_detect_license_Kaspersky.sh
+++ b/bin/watchdog/MC_mod_detect_license_Kaspersky.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+#err_report() {
+#    echo "Error on line $1"
+#}
+#trap 'err_report $LINENO' ERR
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+DEADLINE=7
+# First, check if Kaspersky is installed
+if dpkg-query -s kaspersky-64-2.0 | grep "Status: install ok installed"; then
+   if ! ls /opt/kaspersky-updater/bin/*.key >/dev/null 2>&1; then 
+        echo "License key not found" > $OUT_FILE
+        my_own_exit "1"
+   fi
+   if /opt/kaspersky-updater/bin/keepup2date8.sh --licinfo --simplelic | grep "0x00000000. Success"; then 
+     expirationDate=`/opt/kaspersky-updater/bin/keepup2date8.sh --licinfo --simplelic | sed  -n '8p' | awk -F': ' '{print $2}'`
+     expirationTime=`echo $expirationDate | sed -re 's/(.*)\/(.*)\/(.*)/\2\/\1\/\3/g' | xargs date +"%s" -d`
+     currentTime=`date +"%s"`
+     timeDiff=$(($expirationTime - $currentTime))
+     daysDiff=$(($timeDiff/(3600*24)))
+     if [ $daysDiff -le $DEADLINE ]; then
+       echo "License expired in $daysDiff days ($expirationDate)" > $OUT_FILE
+       my_own_exit "1"
+     fi
+   fi
+fi
+
+
+# A CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_msg_sniffer_db.sh
+++ b/bin/watchdog/MC_mod_detect_msg_sniffer_db.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+if [[ $(grep 'MessageSniffer result is not spam ( - )' /var/mailcleaner/log/mailscanner/infolog.0 |wc -l) > 0 ]]
+then
+    echo "MessageSniffer databases are malformed" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_pyenv_install.sh
+++ b/bin/watchdog/MC_mod_detect_pyenv_install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+
+FILE="/var/mailcleaner/log/mailcleaner/install_pyenv.log"
+ERRNO=`sed 's/\[Errno //' ${FILE} |sed 's/\]:.*//'`
+if [[ $ERRNO -ne 0 ]]; then
+    sed 's/^.*]: //' ${FILE} > $OUT_FILE
+    my_own_exit $ERRNO
+fi
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_detect_unsync_git.sh
+++ b/bin/watchdog/MC_mod_detect_unsync_git.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+GIT_STATUS=$(cd /usr/mailcleaner/ && git status |grep 'Your branch is' | sed -e 's/Your branch is //' | sed -e 's/ .*//')
+if [[ $GIT_STATUS == "up-to-date" ]]; then
+    my_own_exit "0"
+elif [[ $GIT_STATUS == "behind" ]]; then
+    echo "Git tree is behind" > $OUT_FILE
+    my_own_exit "1"
+elif [[ $GIT_STATUS == "ahead" ]]; then
+    echo "Git tree is ahead" > $OUT_FILE
+    my_own_exit "2"
+elif [[ -z $GIT_STATUS ]]; then
+    GIT_STATUS=$(cd /usr/mailcleaner/ && git status |grep 'Your branch' | grep 'have diverged')
+    if [[ -z $GIT_STATUS ]]; then
+       echo "Git tree has diverged" > $OUT_FILE
+       my_own_exit "3"
+    else
+       echo "Git tree had no return" > $OUT_FILE
+       my_own_exit "4"
+    fi
+fi
+
+# CONSERVER !
+my_own_exit "0"
+

--- a/bin/watchdog/MC_mod_disk_full.pl
+++ b/bin/watchdog/MC_mod_disk_full.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/perl -w
+use strict;
+use File::Basename;
+
+my $alarm_limit = 85;
+
+my $script_name         = basename($0);
+my $script_name_no_ext  = $script_name;
+$script_name_no_ext     =~ s/\.[^.]*$//;
+my $timestamp           = time();
+my $rc			= 0;
+
+my $PID_FILE   = '/var/mailcleaner/run/watchdog/' . $script_name_no_ext . '.pid';
+my $OUT_FILE   = '/var/mailcleaner/spool/watchdog/' .$script_name_no_ext. '_' .$timestamp. '.out';
+
+open my $file, '>', $OUT_FILE;
+
+sub my_own_exit {
+    my ($exit_code) = @_;
+    $exit_code = 0  if ( ! defined ($exit_code) );
+
+    if ( -e $PID_FILE ) {
+        unlink $PID_FILE;
+    }
+
+    my $ELAPSED = time() - $timestamp;
+    print $file "EXEC : $ELAPSED\n";
+    print $file "RC : $exit_code\n";
+
+    close $file;
+
+    exit($exit_code);
+}
+
+my @df = `df -h`;
+chomp(@df);
+foreach my $line (@df) {
+	my (undef, $size, $used, undef, $pc, $mount) = split(' ', $line, 6);
+	$pc =~ s/%//;
+
+	if ( ($mount eq '/') || ($mount eq '/var') ) {
+		if ( $pc >= $alarm_limit ) {
+			print $file "$mount : $used / $size => $pc\n";
+			$rc = 1;
+		}
+	}
+}
+
+my_own_exit($rc);

--- a/bin/watchdog/MC_mod_disk_full_inodes.pl
+++ b/bin/watchdog/MC_mod_disk_full_inodes.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/perl -w
+use strict;
+use File::Basename;
+
+my $alarm_limit = 85;
+
+my $script_name         = basename($0);
+my $script_name_no_ext  = $script_name;
+$script_name_no_ext     =~ s/\.[^.]*$//;
+my $timestamp           = time();
+my $rc			= 0;
+
+my $PID_FILE   = '/var/mailcleaner/run/watchdog/' . $script_name_no_ext . '.pid';
+my $OUT_FILE   = '/var/mailcleaner/spool/watchdog/' .$script_name_no_ext. '_' .$timestamp. '.out';
+
+open my $file, '>', $OUT_FILE;
+
+sub my_own_exit {
+    my ($exit_code) = @_;
+    $exit_code = 0  if ( ! defined ($exit_code) );
+
+    if ( -e $PID_FILE ) {
+        unlink $PID_FILE;
+    }
+
+    my $ELAPSED = time() - $timestamp;
+    print $file "EXEC : $ELAPSED\n";
+    print $file "RC : $exit_code\n";
+
+    close $file;
+
+    exit($exit_code);
+}
+
+my @df = `df -i`;
+chomp(@df);
+foreach my $line (@df) {
+	my (undef, $size, $used, undef, $pc, $mount) = split(' ', $line, 6);
+	$pc =~ s/%//;
+
+	if ( ($mount eq '/') || ($mount eq '/var') ) {
+		if ( $pc >= $alarm_limit ) {
+			print $file "$mount : $used / $size => $pc\n";
+			$rc = 1;
+		}
+	}
+}
+
+my_own_exit($rc);

--- a/bin/watchdog/MC_mod_exim_4.92.sh
+++ b/bin/watchdog/MC_mod_exim_4.92.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+EXIT=0
+if [[ $(grep authresults /usr/mailcleaner/etc/exim/exim_stage1.conf_template|wc -l) = 0 ]]
+then
+    echo "/usr/mailcleaner/etc/exim/exim_stage1.conf_template is not up to date" >> $OUT_FILE
+    EXIT=1
+fi
+
+if [[ $(dpkg -l |grep mc-exim | sed -e 's/.*4.92.*/4.92/') != '4.92' ]]
+then
+    echo "mc_exim is not in version 4.92" >> $OUT_FILE
+    EXIT=1
+fi
+
+if [[ ${EXIT} = 1 ]]
+then
+    my_own_exit "1"
+fi
+
+# CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_git_conflicts.sh
+++ b/bin/watchdog/MC_mod_git_conflicts.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+
+
+#### MAIN
+#### Lorsque le module a trouvé une erreur, il est censé sortir avec my_own_exit "#ERREUR" (avec #ERREUR : chiffre : retour de la commande)
+
+if [ -f /root/Updater4MC/updater_$(date +%Y-%m-%d).log ]; then
+    log_file="/root/Updater4MC/updater_$(date +%Y-%m-%d).log"
+else
+    log_file="/root/Updater4MC/updater_$(date +%Y-%m-%d -d yesterday).log"
+fi
+error_result=$(grep \
+    -e "error: The following untracked working tree files would be overwritten by merge:" \
+    $log_file)
+merge_result=$(grep -e "Fast-forward" $log_file)
+
+if [[ -n $error_result && -z $merge_result ]]; then
+    echo "File conflicts when updating MailCleaner" > $OUT_FILE
+    my_own_exit "1"
+fi
+
+# A CONSERVER !
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_resync.sh
+++ b/bin/watchdog/MC_mod_resync.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Récupération du nom du script
+script_name=$(basename $0);
+script_name_no_ext=${script_name%.*}
+# Timestamp => fichier unique et temps d'exécution
+timestamp=`date +%s`
+# Fichier PID et pour écrire le résultat
+PID_FILE="/var/mailcleaner/run/watchdog/$script_name_no_ext.pid"
+OUT_FILE="/var/mailcleaner/spool/watchdog/${script_name_no_ext}_$timestamp.out"
+
+# Fonction de gestion de la sortie du script
+# A appeler également en cas de succès
+# Efface le fichier PID et renseigne le temps d'éxécution et le return code dans le fichier de sortie
+my_own_exit()
+{
+    if [ -f $PID_FILE ]; then
+        rm $PID_FILE
+    fi
+
+    END=`date +%s`
+    ELAPSED=$(($END - $timestamp))
+
+    echo "EXEC : $ELAPSED" >> $OUT_FILE
+    echo "RC : $1" >> $OUT_FILE
+    exit $1
+}
+
+# If file doesn't exist, things are fine
+STATUSFILE=/var/mailcleaner/spool/resync/fail_count
+if [ -e $STATUSFILE ]; then
+    COUNT="`cat $STATUSFILE`"
+    # If running for longer than an hour or exited without cleaning
+    if [[ "$COUNT" -ge 6 ]]; then
+        echo "DBs are out of sync and automatic resync has failed for 1 whole day (6 attempts). No longer attempting automatic correction. Recent configuration changes will not have been be applied. Try manually running /usr/mailcleaner/bin/resync_db.sh" >> $OUT_FILE
+        my_own_exit "2"
+    # If it specifically failed an update
+    else
+        echo "DBs are out of sync and automatic resync has failed $COUNT time(s). A total of 6 automatic attempts to resync will be made. Recent configuration changes will not have been be applied. Try manually running /usr/mailcleaner/bin/resync_db.sh" >> $OUT_FILE
+        my_own_exit "1"
+    fi
+fi
+
+my_own_exit "0"

--- a/bin/watchdog/MC_mod_slave_status.pl
+++ b/bin/watchdog/MC_mod_slave_status.pl
@@ -1,0 +1,44 @@
+#!/usr/bin/perl -w
+use strict;
+use File::Basename;
+
+my $script_name         = basename($0);
+my $script_name_no_ext  = $script_name;
+$script_name_no_ext     =~ s/\.[^.]*$//;
+my $timestamp           = time();
+
+my $PID_FILE   = '/var/mailcleaner/run/watchdog/' . $script_name_no_ext . '.pid';
+my $OUT_FILE   = '/var/mailcleaner/spool/watchdog/' .$script_name_no_ext. '_' .$timestamp. '.out';
+
+open my $file, '>', $OUT_FILE;
+
+sub my_own_exit {
+    my ($exit_code) = @_;
+    $exit_code = 0  if ( ! defined ($exit_code) );
+
+    if ( -e $PID_FILE ) {
+        unlink $PID_FILE;
+    }
+
+    my $ELAPSED = time() - $timestamp;
+    print $file "EXEC : $ELAPSED\n";
+    print $file "RC : $exit_code\n";
+
+    close $file;
+
+    exit($exit_code);
+}
+
+my $slave_status = `echo 'show slave status\\G' |/usr/mailcleaner/bin/mc_mysql -s`;
+
+if ($slave_status eq '') {
+	# Réparer resync_db.sh
+	print $file "Show slave status : Retour vide, faire un sync_db\n";
+    my_own_exit(1);
+
+} elsif ( ($slave_status !~ /Slave_SQL_Running: Yes/) || ($slave_status !~ /Slave_IO_Running: Yes/) ) {
+	print $file "Show slave status : au moins un des process retourne No, faire un sync_db\n";
+    my_own_exit(2);
+}
+
+my_own_exit(0);

--- a/bin/watchdog/watchdogs_report.sh
+++ b/bin/watchdog/watchdogs_report.sh
@@ -8,9 +8,10 @@ DIRBASE='/var/mailcleaner/spool/watchdog/'
 PIDDIR='/var/mailcleaner/run/watchdog/'
 REPORTSWRK=$DIRBASE'reports.wrk'
 FILE=$DIRBASE"reports/report-$CLIENTID-$HOSTID-$TIME.tar.gz"
+WWW='/usr/mailcleaner/www/guis/admin/public/downloads/watchdogs.html'
 
 if [ -e '/var/tmp/mc_checks_data.ko' ]; then
-        exit;
+    exit;
 fi
 
 # Nettoyage
@@ -30,15 +31,60 @@ if [ ! -d "$DIRBASE/reports"  ]; then
     mkdir -p $DIRBASE/reports >/dev/null 2>&1
 fi
 
-mv $DIRBASE/MC_mod*.out $REPORTSWRK/ >/dev/null 2>&1
-cd $DIRBASE >/dev/null 2>&1
-tar cvf - reports.wrk 2>/dev/null  | gzip -9 - > $FILE
-
-scp -q -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $FILE mcscp@team01.mailcleaner.net:/upload/watchdog-reports/ &> /dev/null
-if [[ $? = 0  ]]
-then
-    rm -Rf $REPORTSWRK >/dev/null 2>&1
-    rm $FILE >/dev/null 2>&1
+# Nothing to report
+if [ `ls $DIRBASE/{MC,EE,CUSTOM}_mod_* 2> /dev/null | wc -l` ]; then
+    cp $DIRBASE/{MC,EE,CUSTOM}_mod_*.out $REPORTSWRK/ >/dev/null 2>&1
 else
-    rm $FILE >/dev/null 2>&1
+    rm $WWW
+    exit
+fi
+
+cd $DIRBASE >/dev/null 2>&1
+
+# Admin console data
+for i in `ls $REPORTSWRK`; do
+    TYPE=`echo $i | sed -r 's/(MC|EE|CUSTOM)_mod_(.*)_[0-9]*.out/\1/'`
+    MODULE=`echo $i | sed -r 's/(MC|EE|CUSTOM)_mod_(.*)_[0-9]*.out/\2/'`
+    RC="`cat $REPORTSWRK/$i | grep RC`"
+    DETAIL="`cat $REPORTSWRK/$i | head -n 1`"
+    if grep -qP '(RC|EXEC) : ' <<< `echo $DETAIL`; then
+        DETAIL="No description"
+    fi
+    ENTRY=''
+    if [[ "$RC" != '' && "$RC" != 'RC : 0' ]]; then
+    	ENTRY=$ENTRY'<div>
+    <h3 style="display: inline;">'$MODULE
+        if [[ "$TYPE" != 'MC' ]]; then
+		ENTRY=$ENTRY' ('$TYPE')'
+	fi
+	ENTRY=$ENTRY'</h3></br>
+    <div>
+        '$DETAIL'<br /><br />
+    </div>
+</div>'
+        echo $ENTRY >> ${WWW}.tmp
+    fi
+    # Remove user defined modules before creating archive
+    if [[ "$TYPE" == 'CUSTOM' ]]; then
+        rm $REPORTWRK/$i
+    fi
+done
+if [ -e ${WWW}.tmp ]; then
+    mv ${WWW}.tmp $WWW >/dev/null 2>&1
+else
+    echo "<br/>" > $WWW
+fi
+
+# Report to MailCleaner
+if [ $CLIENTID ]; then
+    tar cvf - reports.wrk 2>/dev/null  | gzip -9 - > $FILE
+    scp -q -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $FILE mcscp@team01.mailcleaner.net:/upload/watchdog-reports/ &> /dev/null
+    if [[ $? = 0  ]]; then
+        rm -Rf $REPORTSWRK >/dev/null 2>&1
+        rm $FILE >/dev/null 2>&1
+    else
+        rm $FILE >/dev/null 2>&1
+    fi
+else
+    rm -Rf $REPORTSWRK >/dev/null 2>&1
 fi

--- a/etc/watchdog/.readme
+++ b/etc/watchdog/.readme
@@ -1,1 +1,11 @@
 Place your Watchdog configuration modules here.
+
+Please respect the following naming conventions:
+
+MC_mod_*	- Default, built-in Community Edition modules
+EE_mod_*	- Additional Enterprise Edition modules
+CUSTOM_mod_*	- Your custom modules
+
+Note that each configuration file must have any accompanying script in ../../bin/watchdog
+
+For more information on existing and custom watchdogs, see: https://support.mailcleaner.net/boards/3/topics/82-watchdogs

--- a/etc/watchdog/MC_fix_pid_files.conf
+++ b/etc/watchdog/MC_fix_pid_files.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_Internal_keys.conf
+++ b/etc/watchdog/MC_mod_Internal_keys.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_Updater_Status.conf
+++ b/etc/watchdog/MC_mod_Updater_Status.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_Updater_TLS.conf
+++ b/etc/watchdog/MC_mod_Updater_TLS.conf
@@ -1,0 +1,2 @@
+TAGS=oneday
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_bad_dumper.conf
+++ b/etc/watchdog/MC_mod_bad_dumper.conf
@@ -1,0 +1,2 @@
+TAGS=oneday
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_F2B.conf
+++ b/etc/watchdog/MC_mod_detect_F2B.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_Spam_Handler.conf
+++ b/etc/watchdog/MC_mod_detect_Spam_Handler.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_StatsDaemon.conf
+++ b/etc/watchdog/MC_mod_detect_StatsDaemon.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_Summaries.conf
+++ b/etc/watchdog/MC_mod_detect_Summaries.conf
@@ -1,0 +1,2 @@
+TAGS=oneday
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_bad_git.conf
+++ b/etc/watchdog/MC_mod_detect_bad_git.conf
@@ -1,0 +1,3 @@
+TIMEOUT=5
+TAGS=oneday
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_license_Kaspersky.conf
+++ b/etc/watchdog/MC_mod_detect_license_Kaspersky.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_msg_sniffer_db.conf
+++ b/etc/watchdog/MC_mod_detect_msg_sniffer_db.conf
@@ -1,0 +1,2 @@
+TAGS=oneday
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_pyenv_install.conf
+++ b/etc/watchdog/MC_mod_detect_pyenv_install.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_detect_unsync_git.conf
+++ b/etc/watchdog/MC_mod_detect_unsync_git.conf
@@ -1,0 +1,3 @@
+TIMEOUT=5
+EXEC_MODE=Parralel
+TAGS=oneday

--- a/etc/watchdog/MC_mod_disk_full.conf
+++ b/etc/watchdog/MC_mod_disk_full.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_disk_full_inodes.conf
+++ b/etc/watchdog/MC_mod_disk_full_inodes.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_exim_4.92.conf
+++ b/etc/watchdog/MC_mod_exim_4.92.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_resync.conf
+++ b/etc/watchdog/MC_mod_resync.conf
@@ -1,0 +1,2 @@
+TAGS=all dix
+EXEC_MODE=Parralel

--- a/etc/watchdog/MC_mod_slave_status.conf
+++ b/etc/watchdog/MC_mod_slave_status.conf
@@ -1,0 +1,3 @@
+TIMEOUT=5
+EXEC_MODE=Parralel
+TAGS=oneday

--- a/www/guis/admin/public/templates/default/css/global.css
+++ b/www/guis/admin/public/templates/default/css/global.css
@@ -68,7 +68,7 @@ textarea {
    padding: 30px;
    font-size: 12px;
    color: #666666;
-   max-width: 600px;
+   max-width: 720px;
    margin-left: auto;
    margin-right: auto;
 }
@@ -76,7 +76,7 @@ textarea {
    text-align: center;
    border: 1px solid #D4D3D2 !important;
    padding: 0px;
-   max-width: 600px;
+   max-width: 720px;
    margin-left: auto;
    margin-right: auto;
    margin-top: 20px;
@@ -90,7 +90,7 @@ textarea {
 }
 
 .globalbloc {
-   max-width: 600px;
+   max-width: 720px;
    margin-left: auto;
    margin-right: auto;
    background-color: #FFFFFF;
@@ -122,7 +122,7 @@ textarea {
 }
 
 .registerbloc {
-   max-width: 600px;
+   max-width: 720px;
    margin-left: auto;
    margin-right: auto;
    background-color: #FFFFFF;
@@ -157,7 +157,7 @@ textarea {
 
 .countsbloc {
 	position: absolute;
-	width: 600px;
+	width: 720px;
 }
 .globalstatstable {
   float: right;
@@ -192,7 +192,7 @@ textarea {
   text-align: center !important;
   height: 206px;
   line-height: 206px;
-  width: 600px !important;
+  width: 720px !important;
 }
 #globalstatusloaading {
   height: 166px;

--- a/www/guis/admin/public/templates/default/scripts/index/index.phtml
+++ b/www/guis/admin/public/templates/default/scripts/index/index.phtml
@@ -1,167 +1,219 @@
 <p class="welcome"><?php echo $this->t->_('Welcome to MailCleaner administration panel')?></p>
 
 <?php 
-     $user = Zend_Registry::get('user'); 
-     $sysconf = MailCleaner_Config::getInstance();
+$user = Zend_Registry::get('user'); 
+$mcconfig = MailCleaner_Config::getInstance();
+
+if ($user && $user->getUserType() == 'administrator') {
+    if (!$this->is_registered) {
 ?>
 
-<?php if ($user && $user->getUserType() == 'administrator') {?>
-
-<?php if (!$this->is_registered) { ?>
 <div id="RegisterBloc" class="registerbloc">
-  <h1>Register - Get add-ons</h1>
+    <h1>Register - Get add-ons</h1>
     <div class="registerblocdiv">
-     <table style="width:100%">
-          <tr>
-              <th class="registerbloccolumn">Free Entreprise Edition trial</th>
-              <th class="registerbloccolumn">Get commercial Add-ons</th>
-              <th class="registerbloccolumn">Community Edition Registration</th>
-          </tr>
-	  <tr>
-             <td>Test the Enterprise Edition
-                <div>
-                     <table>
+        <table style="width:100%">
+            <tr>
+                <th class="registerbloccolumn">Free Entreprise Edition trial</th>
+                <th class="registerbloccolumn">Get commercial Add-ons</th>
+                <th class="registerbloccolumn">Community Edition Registration</th>
+            </tr>
+	        <tr>
+                <td>Test the Enterprise Edition
+                    <div>
+                        <table>
                             <tbody>
-                                   <tr>
-                                       <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                       </td>
-                                       <td class=globalstatusvalue">Commercial RBLs
-                                       </td>
-                                   </tr>
-                                   <tr>
-                                      <td class="globalstatuskey">
-                                          <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                      </td>
-                                      <td class=globalstatusvalue">Additionnal filtering rules
-                                      </td>
-                                   </tr>
-                                   <tr>
-                                      <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                      </td>
-                                      <td class=globalstatusvalue">Support
-                                      </td>
-                                   </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">Commercial RBLs
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">Additionnal filtering rules
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">Support
+                                    </td>
+                                </tr>
                             </tbody>
-                     </table>
-                </div>
-             </td>
-             <td>You can add
-                <div>
-                     <table>
+                        </table>
+                    </div>
+                </td>
+                <td>You can add
+                    <div>
+                        <table>
                             <tbody>
-                                   <tr>
-                                       <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                       </td>
-                                       <td class=globalstatusvalue">Kaspersky
-                                       </td>
-                                   </tr>
-                                   <tr>
-                                      <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                      </td>
-                                      <td class=globalstatusvalue">Spamhaus RBL
-                                      </td>
-                                   </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">Kaspersky
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">Spamhaus RBL
+                                    </td>
+                                </tr>
                             </tbody>
-                     </table>
-                </div>
-             </td>
-             <td>Register your free Community Edition to
-                <div>
-                     <table>
+                            </table>
+                    </div>
+                </td>
+                <td>Register your free Community Edition to
+                    <div>
+                        <table>
                             <tbody>
-                                   <tr>
-                                       <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">be added to our newsletter
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">get updates notices
                                        </td>
-                                       <td class=globalstatusvalue">be added to our newsletter
-                                       </td>
-                                   </tr>
-                                   <tr>
-                                      <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                      </td>
-                                      <td class=globalstatusvalue">get updates notices
-                                       </td>
-                                   </tr>
-                                   <tr>
-                                      <td class="globalstatuskey">
-                                           <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
-                                      </td>
-                                      <td class=globalstatusvalue">free updates for the bayesian filters
-                                      </td>
-                                   </tr>
+                                </tr>
+                                <tr>
+                                    <td class="globalstatuskey">
+                                        <img style="width: 50%" src="/admin/templates/default/images/status_ok.png" alt="ok">
+                                    </td>
+                                    <td class=globalstatusvalue">free updates for the bayesian filters
+                                    </td>
+                                </tr>
                             </tbody>
-                     </table>
-                </div>
-             </td>
-          </tr>
-          <tr>
-              <td><a class="notunderlined" href="https://www.mailcleaner.net/trial-request.html?key=Tx3kshaf7324fdD0!" target="_blank"><input type="button" class="linkrebutton" value="Enterprise Edition Trial" /></a></td>
-              <td><a class="notunderlined" href="https://www.mailcleaner.net/community-edition-add-ons.html" target="_blank"><input type="button" class="linkrebutton" value="Purchase Add-ons" /></a></td>
-              <td><a class="notunderlined" href="/admin/baseconfiguration/registration"><input type="button" class="linkrebutton" value="Register your Community Edition" /></a></td>
-          </tr>
-    </table>
-   </div>
+                        </table>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <a class="notunderlined" href="https://www.mailcleaner.net/trial-request.html?key=Tx3kshaf7324fdD0!" target="_blank">
+                        <input type="button" class="linkrebutton" value="Enterprise Edition Trial" />
+                    </a>
+                </td>
+                <td>
+                    <a class="notunderlined" href="https://www.mailcleaner.net/community-edition-add-ons.html" target="_blank">
+                        <input type="button" class="linkrebutton" value="Purchase Add-ons" />
+                    </a>
+                </td>
+                <td>
+                    <a class="notunderlined" href="/admin/baseconfiguration/registration">
+                        <input type="button" class="linkrebutton" value="Register your Community Edition" />
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </div>
 </div>
-<?php } ?>
-
+<?php
+    }
+?>
 <div class="globalbloc" style="min-height: 0px; padding-bottom: 12px;">
      <h1>InfoBox by MailCleaner Team</h1>
      <div class="maclasseamoi" style="min-height: 20px; max-height: 240px; padding: 6px 12px; overflow-y: scroll; text-align: justify">
-<?php } ?>
-
 <?php
+} 
+
 $urltoget='https://www.mailcleaner.net/infobox/';
 
 if ($user && $user->getUserType() == 'administrator') {
-        if ($sysconf->getOption('REGISTERED') == "1")
-                $urltoget = $urltoget.'mc-info-box.php';
-        else
-                $urltoget = $urltoget.'mc-ce-info-box.php';
-        $curl = curl_init();
+    if ($mcconfig->getOption('REGISTERED') == "1") {
+        $urltoget = $urltoget.'mc-info-box.php';
+    } else {
+        $urltoget = $urltoget.'mc-ce-info-box.php';
+    }
 	
+    $curl = curl_init();
 	curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 3); 
 	curl_setopt($curl, CURLOPT_TIMEOUT, 3); //timeout in seconds
-        curl_setopt_array($curl, array(
-                CURLOPT_RETURNTRANSFER => 1,
-                CURLOPT_URL => $urltoget,
-                CURLOPT_FAILONERROR => true
-        ));
-        $result = curl_exec($curl);
-        if ($result === false)
-          echo "No text or no access to remote server.";
-        else
-          echo $result;
+    curl_setopt_array($curl, array(
+        CURLOPT_RETURNTRANSFER => 1,
+        CURLOPT_SSL_VERIFYHOST => 0,
+        CURLOPT_SSL_VERIFYPEER => 0,
+        CURLOPT_URL => $urltoget,
+        CURLOPT_FAILONERROR => true
+    ));
 
-        echo "</div></div>";
+    $result = curl_exec($curl);
+    if ($result === false) {
+        echo "No text or no access to remote server.";
+    } else {
+        echo $result;
+    }
+
+    echo "</div></div></div>";
 }
+
+if (!$this->is_slave) { 
 ?>
-
-<?php if (!$this->is_slave) { ?>
 <div id="globalstatsbloc" class="globalbloc globalstatbloc">
-  <div id="countsbloc1" class="countsbloc">
-  <h1><?php echo $this->t->_('Today\'s counts');?></h1>
-  <div id="globalstatsloaading" class="globaldataloading">
-    <img src="<?php echo $this->images_path?>/loadingwhitebg.gif" alt="loading" />
-  </div>
-  </div>
-  <div id="countsbloc2" class="countsbloc hidden"></div>
+    <div id="countsbloc1" class="countsbloc">
+        <h1><?php echo $this->t->_('Today\'s counts');?></h1>
+        <div id="globalstatsloaading" class="globaldataloading">
+            <img src="<?php echo $this->images_path?>/loadingwhitebg.gif" alt="loading" />
+        </div>
+    </div>
+    <div id="countsbloc2" class="countsbloc hidden"></div>
 </div>
-
-  <?php $user = Zend_Registry::get('user'); ?>
-  <?php if ($user && $user->getUserType() == 'administrator') {?>
-
+<?php 
+    $user = Zend_Registry::get('user');
+    if ($user && $user->getUserType() == 'administrator') {
+?>
 <div id="globalstatusbloc" class="globalbloc globalstatusbloc">
    <h1><?php echo $this->t->_('Overall system\'s status')?></h1>
    <div id="globalstatusloaading" class="globaldataloading">
-     <img src="<?php echo $this->images_path?>/loadingwhitebg.gif" alt="loading" />
+        <img src="<?php echo $this->images_path?>/loadingwhitebg.gif" alt="loading" />
    </div>
 </div>
+<?php
 
-  <?php } ?>
-
-<?php }?>
+        $watchdogs = '';
+        $slave = new Default_Model_Slave();
+        if ($user && $user->getUserType() == 'administrator') {
+            $urltoget = '/admin/downloads/watchdogs.html';
+            $curl = curl_init();
+	    
+            $id = 1;
+            foreach ($slave->fetchAll() as $s) {
+	            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 3); 
+	            curl_setopt($curl, CURLOPT_TIMEOUT, 3); //timeout in seconds
+                curl_setopt_array($curl, array(
+                    CURLOPT_RETURNTRANSFER => 1,
+                    CURLOPT_SSL_VERIFYHOST => 0,
+                    CURLOPT_SSL_VERIFYPEER => 0,
+                    CURLOPT_URL => "https://". $s->getHostname() . $urltoget,
+                    CURLOPT_FAILONERROR => true
+                ));
+                $result = curl_exec($curl);
+                if ($result !== false && !preg_match('/^<!DOCTYPE/',$result) && !preg_match('/^\s*<br\/>\s*$/',$result)) {
+                    $watchdogs .= "<h3>Host " . $s->getId() . " - " . $s->getHostname() . "</h3>$result<hr/>";
+                }
+            }
+        }
+        if ($watchdogs != '') {
+?>
+<div class="globalbloc" style="min-height: 0px; padding-bottom: 12px;">
+    <h1>System Warnings (<a href="https://support.mailcleaner.net/boards/3/topics/82-watchdogs">Resolution advice here</a>)</h1>
+    <div class="maclasseamoi" style="min-height: 20px; max-height: 240px; padding: 6px 12px; overflow-y: scroll; text-align: justify">
+    <?php print $watchdogs ?>
+    </div>
+</div>
+<?php 
+        }
+    }
+}
+?>


### PR DESCRIPTION
Change rotation procedure to maintain output files until next run.
Add HTML page generation for failed watchdogs.
Add EE and CUSTOM module types to differentiate from Community (MC)
Track all non-enterprise watchdogs
Ignore EE and CUSTOM watchdogs more specifically
Display Watchdogs for all hosts in index.phtml (the Admin homepage)
Widen homepage elements slightly (rendering issue with some browsers with larger button sizes, unrelated to watchdogs)