### PR TITLE
UNTESTED! Allow exception in hostlists

### DIFF
--- a/lib/GetDNS.pm
+++ b/lib/GetDNS.pm
@@ -2,8 +2,13 @@ package GetDNS;
 
 use strict;
 use warnings;
+no warnings qw ( portable overflow ); # Avoid warnings for the temporary use of >64bit numbers
 use Net::DNS;
+use Net::CIDR qw( cidradd cidr2range range2cidr );
+use Math::Int128 qw( int128 );
 use Data::Validate::IP;
+
+our $debug = 1;
 
 sub new
 {
@@ -50,18 +55,25 @@ sub dumper {
 		# Push without looking up DNS info
 		if ($line =~ m/^([a-z0-9\-*]+\.)+[a-z]*$/) {
 			push(@list,$line);
+		# Ignore comment
+		} elsif ($line =~ m/^#/) {
+			next;
 		} else {
 			$cache{$line} = undef;
 		}
 	}
 
 	my @invalid;
+	my @exceptions;
 	my $continue;
 	do {
 		foreach my $item (keys %cache) {
 			if ($item eq '*') {
 				$self->{recursion} = $recursion;
 				return ( '::0/0', '0.0.0.0/0' );
+			} elsif ($item =~ m#^\!(.*)$#) {
+				push(@exceptions, $1);
+                                delete($cache{$item});
 			} elsif (defined($cache{$item})) {
 				next;
 			} elsif ($item =~ m#\*#) {
@@ -148,8 +160,14 @@ sub dumper {
 		}
 	}
 			
+	if (scalar(@exceptions)) {
+		@exceptions = $self->dumper(join(' ',@exceptions));
+	}
+
+	@list = $self->simplify(\@list,\@exceptions);
+
 	$self->{recursion} = $recursion;
-	return $self->uniq(@list);
+	return @list;
 }
 			
 sub getA
@@ -325,6 +343,248 @@ sub inIPList
 	return 0;
 }
 
+sub simplify
+{
+	my $self = shift;
+	my $list = shift;
+	my $exceptions = shift;
+
+	my ($wanted4, $wanted6) = $self->merge($list);
+
+	unless (scalar(@{$exceptions})) {
+		return ( @{$wanted4}, @{$wanted6} );
+	}
+
+	my ($unwanted4, $unwanted6) = $self->merge($exceptions);
+
+	my @unwanted4 = @{$unwanted4};
+	my @wanted4 = @{$wanted4};
+	foreach my $block (cidr2range(@unwanted4)) {
+		my ($ubottom, $utop) = split('-',$block);
+		my @new_wanted;
+		while (scalar(@wanted4)) {
+			my $current = shift(@wanted4);
+			my ($wbottom, $wtop) = split('-',(cidr2range($current))[0]);
+			my $string;
+			my $continue = 1;
+			# No overlap
+			if (ip4todec($ubottom) > ip4todec($wtop) || ip4todec($utop) < ip4todec($wbottom)) {
+				$string .= "No overlap";
+				push( @new_wanted, $current );
+			# Starts before, ends after
+			} elsif (ip4todec($ubottom) < ip4todec($wbottom) && ip4todec($utop) > ip4todec($wtop)) {
+				$string .= "Starts before, ends after";
+			# Match beginning
+			} elsif (ip4todec($ubottom) == ip4todec($wbottom)) {
+				# Match end, remove exact match and jump to next
+ 				if (ip4todec($utop) == ip4todec($wtop)) {
+					$string .= "Exact match";
+					@new_wanted = ( @new_wanted, @wanted4 );
+					$continue = 0;
+				# Ends after, remove entire block, but look for other matches
+ 				} elsif (ip4todec($utop) > ip4todec($wtop)) {
+					$string .= "Same start, ends after";
+				# Ends before, shift start
+				} else {
+					$string .= "Same start, ends before";
+					push( @new_wanted, range2cidr((dectoip4(ip4todec($utop)+1)).'-'.$wtop ));
+				}
+			# Match end
+			} elsif (ip4todec($utop) == ip4todec($wtop)) {
+				# Starts before, remove entire block, but look for other matches
+ 				if (ip4todec($ubottom) < ip4todec($wbottom)) {
+					$string .= "Starts before, same end";
+				# Starts after, shift start
+				} else {
+					$string .= "Starts after, same end";
+					push( @new_wanted, range2cidr($wbottom.'-'.dectoip4(ip4todec($ubottom)-1)) );
+					@new_wanted = ( @new_wanted, @wanted4 );
+					$continue = 0;
+				}
+			# Mid-range, add preceding and following blocks
+			} elsif (ip4todec($ubottom) > ip4todec($wbottom) && ip4todec($utop) < ip4todec($wtop))  {
+				$string .= "Mid-range";
+				push( @new_wanted, range2cidr($wbottom.'-'.dectoip4(ip4todec($utop)-1)) );
+				push( @new_wanted, range2cidr((dectoip4(ip4todec($utop)+1)).'-'.$wtop ));
+				@new_wanted = ( @new_wanted, @wanted4 );
+				$continue = 0;
+			# Starts after, ends after, shift start; should not be possible
+			} elsif (ip4todec($ubottom) > ip4todec($wbottom)) {
+				$string .= "INVALID, starts after and continues";
+				push( @new_wanted, range2cidr($wbottom.'-'.dectoip4(ip4todec($ubottom)-1)) );
+			# Starts before, ends before, push start; should not be possible
+			} elsif (ip4todec($utop) < ip4todec($wtop)) {
+				$string .= "INVALID, Starts before, ends mid-way";
+				push( @new_wanted, range2cidr(dectoip4(ip4todec($utop)+1)).'-'.$wtop );
+			# Default should not ever hit
+			} else {
+				$string .= "This should not be possible";
+			}
+			if ($debug) {
+				if (defined($string)) {
+					print "unwanted: $block, wanted: $wbottom-$wtop - $string\n";
+				} else {
+					print "unwanted: $block, wanted: $wbottom-$wtop - No match\n";
+				}
+			}
+			unless ($continue) {
+				last;
+			}
+		}
+		@wanted4 = @new_wanted;
+	}
+
+	my @unwanted6 = @{$unwanted6};
+	my @wanted6 = @{$wanted6};
+	foreach my $block (cidr2range(@unwanted6)) {
+		my ($ubottom, $utop) = split('-',$block);
+		my @new_wanted;
+		while (scalar(@wanted6)) {
+			my $current = shift(@wanted6);
+			my ($wbottom, $wtop) = split('-',(cidr2range($current))[0]);
+			my $string;
+			my $continue = 0;
+			# No overlap
+			if (ip6todec($ubottom) > ip6todec($wtop) || ip6todec($utop) < ip6todec($wbottom)) {
+				$string .= "No overlap";
+				push( @new_wanted, $current );
+			# Starts before, ends after
+			} elsif (ip6todec($ubottom) < ip6todec($wbottom) && ip6todec($utop) > ip6todec($wtop)) {
+				$string .= "Starts before, ends after";
+			# Match beginning
+			} elsif (ip6todec($ubottom) == ip6todec($wbottom)) {
+				# Match end, remove exact match and jump to next
+ 				if (ip6todec($utop) == ip6todec($wtop)) {
+					$string .= "Exact match";
+					@new_wanted = ( @new_wanted, @wanted6 );
+					$continue = 0;
+				# Ends after, remove entire block, but look for other matches
+ 				} elsif (ip6todec($utop) > ip6todec($wtop)) {
+					$string .= "Same start, ends after";
+				# Ends before, shift start
+				} else {
+					$string .= "Same start, ends before";
+					push( @new_wanted, range2cidr((dectoip6(ip6todec($utop)+1)).'-'.$wtop ));
+				}
+			# Match end
+			} elsif (ip6todec($utop) == ip6todec($wtop)) {
+				# Starts before, remove entire block, but look for other matches
+ 				if (ip6todec($ubottom) < ip6todec($wbottom)) {
+				$string .= "Starts before, same end";
+				# Starts after, shift start
+				} else {
+				$string .= "Starts after, same end";
+					push( @new_wanted, range2cidr($wbottom.'-'.dectoip6(ip6todec($ubottom)-1)) );
+					@new_wanted = ( @new_wanted, @wanted6 );
+					$continue = 0;
+				}
+			# Mid-range, add preceding and following blocks
+			} elsif (ip6todec($ubottom) > ip6todec($wbottom) && ip6todec($utop) < ip6todec($wtop))  {
+				$string .= "Mid-range";
+				push( @new_wanted, range2cidr($wbottom.'-'.dectoip6(ip6todec($utop)-1)) );
+				push( @new_wanted, range2cidr((dectoip6(ip6todec($utop)+1)).'-'.$wtop ));
+				@new_wanted = ( @new_wanted, @wanted6 );
+				$continue = 0;
+			# Starts after, ends after, shift start; should not be possible
+			} elsif (ip6todec($ubottom) > ip6todec($wbottom)) {
+				$string .= "INVALID, starts after and continues";
+				push( @new_wanted, range2cidr($wbottom.'-'.dectoip6(ip6todec($ubottom)-1)) );
+			# Starts before, ends before, push start; should not be possible
+			} elsif (ip6todec($utop) < ip6todec($wtop)) {
+				$string .= "INVALID, Starts before, ends mid-way";
+				push( @new_wanted, range2cidr(dectoip6(ip6todec($utop)+1)).'-'.$wtop );
+			# Default should not ever hit
+			} else {
+				$string .= "This should not be possible";
+			}
+			if ($debug) {
+				if (defined($string)) {
+					print "unwanted: $block, wanted: $wbottom-$wtop - $string\n";
+				} else {
+					print "unwanted: $block, wanted: $wbottom-$wtop - No match\n";
+				}
+			}
+			unless ($continue) {
+				last;
+			}
+		}
+		@wanted6 = @new_wanted;
+	}
+
+	return ( @wanted4, @wanted6 );
+}
+
+sub merge
+{
+	my $self = shift;
+	my $list = shift;
+	my (@ip4, @ip6);
+	foreach (@{$list}) {
+		if ($_ =~ m/:/) {
+			@ip6 = cidradd($_,@ip6);
+		} else {
+			@ip4 = cidradd($_,@ip4);
+		}
+	}
+
+	return ( \@ip4, \@ip6 );
+}
+
+sub ip4todec
+{
+	my @bytes = split /\./, shift;
+	return ($bytes[0] << 24) + ($bytes[1] << 16) + ($bytes[2] << 8) + $bytes[3];
+}
+
+sub dectoip4
+{
+	my $decimal = shift;
+	my @bytes;
+	push @bytes, ($decimal & 0xff000000) >> 24;
+	push @bytes, ($decimal & 0x00ff0000) >> 16;
+	push @bytes, ($decimal & 0x0000ff00) >>  8;
+	push @bytes, ($decimal & 0x000000ff);
+	return join '.', @bytes;
+}
+
+sub ip6todec
+{
+	my @bytes = split(/:/, expandip6(shift));
+	my $decimal = 0;
+	return (int128(hex($bytes[0])) << 112) + (int128(hex($bytes[1])) << 96) + (int128(hex($bytes[2])) << 80) + (int128(hex($bytes[3])) << 64) + (hex($bytes[4]) << 48) + (hex($bytes[5]) << 32) + (hex($bytes[6]) << 16) + hex($bytes[7]);
+}
+
+sub dectoip6
+{
+	my $decimal = int128(shift);
+	my @bytes;
+	push( @bytes, sprintf("%x", ($decimal & 0xffff0000000000000000000000000000) >> 112) );
+	push( @bytes, sprintf("%x", ($decimal & 0x0000ffff000000000000000000000000) >>  96) );
+	push( @bytes, sprintf("%x", ($decimal & 0x00000000ffff00000000000000000000) >>  80) );
+	push( @bytes, sprintf("%x", ($decimal & 0x000000000000ffff0000000000000000) >>  64) );
+	push( @bytes, sprintf("%x", ($decimal & 0x0000000000000000ffff000000000000) >>  48) );
+	push( @bytes, sprintf("%x", ($decimal & 0x00000000000000000000ffff00000000) >>  32) );
+	push( @bytes, sprintf("%x", ($decimal & 0x000000000000000000000000ffff0000) >>  16) );
+	push( @bytes, sprintf("%x", ($decimal & 0x0000000000000000000000000000ffff)       ) );
+	return join ':', @bytes;
+}
+
+sub expandip6
+{
+	my $ip = shift;
+	if ($ip =~ m/^:/) {
+		$ip = "0$ip";
+	}
+	if ($ip =~ m/:$/) {
+		$ip .= "0";
+	}
+	if ($ip =~ m/::/) {
+		my $missing = '0:' x (9-(scalar(split(/:/, $ip))));
+		$ip =~ s/::/:$missing/;
+	}
+	return $ip;
+}
+
 sub uniq
 {
 	my $self = shift;
@@ -340,6 +600,7 @@ sub uniq
 		push(@uniq, $_);
 	}
 
-	return @uniq
+	return @uniq;
 }
+
 1;

--- a/tools/ip_exemption_test.pl
+++ b/tools/ip_exemption_test.pl
@@ -1,0 +1,87 @@
+#!/usr/bin/perl -w
+
+use strict;
+use File::Copy;
+use File::Path;
+if ($0 =~ m/(\S*)\/\S+.pl$/) {
+  my $path = $1."/../lib";
+  unshift (@INC, $path);
+}
+require MCDnsLists;
+require GetDNS;
+require DB;
+
+our %tables = (
+        'trusted_ips'                   => 'antispam',
+        'html_wl_ips'                   => 'antispam',
+        'relay_from_hosts'              => 'exim_stage1',
+        'no_ratelimit_hosts'            => 'exim_stage1',
+        'host_reject'                   => 'exim_stage1',
+        'hosts_require_tls'             => 'exim_stage1',
+        'rbls_ignore_hosts'             => 'exim_stage1',
+        'spf_dmarc_ignore_hosts'        => 'exim_stage1'
+);
+
+my $file = shift || usage("Missing argument");
+
+my @ips;
+if ($file =~ m/^--/) {
+	$file =~ s/^--//;
+	if (defined($tables{$file})) {
+		@ips = get_from_db($tables{$file},$file);
+	} else {
+		usage("unknown column '$file'");
+	}
+} else {
+	open(my $fh, '<', $file) || usage("Failed to open $file");
+	my $raw;
+	while (<$fh>) {
+		$raw .= $_;
+	}
+	close($fh);
+	if ($raw eq '') {
+		usage("$file is empty");
+	}
+	@ips = ( expand_host_string($raw, ('dumper'=>'exemption_test_script')) );
+}
+
+foreach (@ips) {
+	print "$_\n";
+}
+
+sub get_from_db
+{
+	my ($table, $column) = @_;
+	my $stage;
+	if ($table =~ m/^exim_stage(\d)$/) {
+		$stage = $1;
+		$table = "mta_config WHERE stage = '$1'";
+	}
+	my $db = DB::connect('slave', 'mc_config');
+
+	my %row = $db->getHashRow("SELECT $column FROM $table");
+	return ( expand_host_string($row{$column}, ('dumper'=>"exemption_test_script/$column")) );
+}
+
+sub expand_host_string
+{
+    my $string = shift;
+    my %args = @_;
+    my $dns = GetDNS->new();
+    return $dns->dumper($string,%args);
+}
+
+sub usage
+{
+	my $error;
+	if ($error = shift) {
+		print "\nERROR: $error\n";
+	}
+	print "\nUsage: $0 <filepath>\n\n";
+	print "File should contain valid hostlist contents.\n\n";
+	print "Alternatively you can fetch one of the hostlists from the DB with:\n";
+	foreach my $column (keys(%tables)) {
+		printf("  --%-24s  (%s)\n", $column, $tables{$column});
+	}
+	die("\n");
+}

--- a/www/guis/admin/application/library/Validate/HostList.php
+++ b/www/guis/admin/application/library/Validate/HostList.php
@@ -38,7 +38,12 @@ class Validate_HostList extends Zend_Validate_Abstract
         }
         $hosts = preg_split('/[,\s]+/', $value);
         foreach ($hosts as $host) {
-          $host = preg_replace('/\/\d+/', '', $host);
+          if (preg_match('/^#/', $host)) {
+              continue;
+          }
+          $host = preg_replace('/^\!?/', '', $host);
+          $host = preg_replace('/\/([0-9]?[0-9]|1([01][0-9]|2[0-8]))$/', '', $host);
+          #$host = preg_replace('/\/([12]?[0-9]|3[0-2])$/', '', $host);
           $host = preg_replace('/(.*)\/(a|A|aaaa|AAAA|mx|MX)$/', '\1', $host);
           $host = preg_replace('/(_)*(.*)\/(spf|spf)$/', '\2', $host);
           if (! $validator->isValid($host)) {

--- a/www/guis/admin/application/library/Validate/IpList.php
+++ b/www/guis/admin/application/library/Validate/IpList.php
@@ -33,11 +33,24 @@ class Validate_IpList extends Zend_Validate_Abstract
         if ($value == '*') {
         	return true;
         }
+        $lines = preg_split('/\n+/', $value);
+        $value = '';
+	foreach ($lines as $line) {
+          if (preg_match('/^#/', $line)) {
+              continue;
+          } else {
+              $value .= $line . ',';
+          }
+        }
         $addresses = preg_split('/[,\s]+/', $value);
         foreach ($addresses as $address) {
-          $address = preg_replace('/\/\d+$/', '', $address);
+          if (preg_match('/^\s*$/', $address)) {
+              continue;
+          }
+          $address = preg_replace('/^\!?/', '', $address);
+          $address = preg_replace('/\/([0-9]?[0-9]|1([01][0-9]|2[0-8]))$/', '', $address);
           if (preg_match('/\/(a|A|aaaa|AAAA|mx|MX|spf|SPF)$/', $address)) {
-		next;
+              continue;
           } elseif (! $validator->isValid($address)) {
           	  $this->ip = $address;
           	  $this->_error(self::MSG_BADIP);

--- a/www/guis/admin/application/library/Validate/SMTPHostList.php
+++ b/www/guis/admin/application/library/Validate/SMTPHostList.php
@@ -38,10 +38,16 @@ class Validate_SMTPHostList extends Zend_Validate_Abstract
           if ($host == '+') {
           	 continue;
           }
+          if (preg_match('/^#/', $host)) {
+              continue;
+          }
+// TODO: check ipv6 workflow
           if (!preg_match('/^[a-f0-9:]+$/', $host)) { # avoid breaking ipv6
               $host = preg_replace('/::?\d+/', '', $host);
           }
-          $host = preg_replace('/\/\d{1,2}/', '', $host);
+          $host = preg_replace('/^\!?/', '', $host);
+          $host = preg_replace('/\/([0-9]?[0-9]|1([01][0-9]|2[0-8]))$/', '', $host);
+          #$host = preg_replace('/\/([12]?[0-9]|3[0-2])$/', '', $host);
           $host = preg_replace('/\/(a|A|aaaa|AAAA|mx|MX)$/', '', $host);
           $host = preg_replace('/(_)*(.*)\/(spf|SPF)$/', '\2', $host);
           $host = preg_replace('/\*/', '', $host);


### PR DESCRIPTION
New dependency:  Math::Int128  (not available in Jessie; use CPAN)

Allows for an exception to an existing IP range:

0.0.0.0/30
!0.0.0.1

Upon dumping, IP math will output the minimum remaining IP ranges:

0.0.0.0/32
0.0.0.2/31

Also allows for commented lines in hostlist fields:

\# Explain following exception
!0.0.0.0

Also included is ip_exemption_test.pl to allow for testing of IP math.