### PR TITLE
Prepare for Exim 4.94.2

### DIFF
--- a/etc/exim/exim_stage1.conf_template_4.94
+++ b/etc/exim/exim_stage1.conf_template_4.94
@@ -1,0 +1,1317 @@
+######################################################################
+#                    MAIN CONFIGURATION SETTINGS                     #
+######################################################################
+
+VARDIR = __VARDIR__
+SRCDIR = __SRCDIR__
+BYPASSDIR = VARDIR/spool/tmp/exim_stage1/bypass
+ARCHIVERDIR = VARDIR/spool/tmp/exim_stage1/archiver
+COPYTODIR = VARDIR/spool/tmp/exim_stage1/copyto
+SENDERBLACKLIST = VARDIR/spool/tmp/exim/blacklists/senders
+RECIPIENTBLACKLIST = VARDIR/spool/tmp/exim/blacklists/recipients
+USERBLACKLIST = VARDIR/spool/tmp/exim/blacklists/users
+HOSTBLACKLIST = VARDIR/spool/tmp/exim/blacklists/hosts
+NORBLHOSTS = VARDIR/spool/tmp/exim/rbl_ignore_hosts
+NOSPFDMARCHOSTS = VARDIR/spool/tmp/exim/spf_and_dmarc_ignore_hosts
+ADDRESSESDIR = VARDIR/spool/mailcleaner/addresses
+DKIMFILE = VARDIR/spool/tmp/mailcleaner/domains_to_dkim.list
+FROZENSENDERS = VARDIR/spool/tmp/exim/frozen_senders
+
+__INCLUDE__ stage1/ldap
+
+av_scanner = clamd:127.0.0.1 3310
+
+__IF__ USESSMTPPORT
+daemon_smtp_ports = 25:587:465
+tls_on_connect_ports = 465
+__ELSE__ USESSMTPPORT
+daemon_smtp_ports = 25:587
+__FI__
+local_interfaces = <; ::0 ; 0.0.0.0
+__IF__ DISABLE_IPV6
+disable_ipv6 = true
+__FI__
+
+__IF__ USETLS
+tls_advertise_hosts = *
+tls_certificate = __VARDIR__/spool/tmp/exim/certificate
+tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
+tls_require_ciphers = __CIPHERS__
+openssl_options = +no_sslv2 +no_sslv3
+__ELSE__ USETLS
+tls_advertise_hosts =
+__FI__
+
+chunking_advertise_hosts =
+keep_environment =
+
+smtp_active_hostname = __HELO_NAME__
+qualify_domain = __HELO_NAME__
+qualify_recipient = __QUALIFY_RECIPIENT__
+smtp_banner = __SMTP_BANNER__
+__IF__ ERRORS_REPLY_TO
+errors_reply_to = __ERRORS_REPLY_TO__
+__FI__
+
+__INCLUDE__ stage1/log_selector
+
+message_logs = true
+exim_user = mailcleaner
+exim_group = mailcleaner
+log_file_path = __IF_USE_SYSLOGENABLED__ VARDIR/log/exim_stage1/%slog
+pid_file_path = VARDIR/run/exim_stage1.pid
+spool_directory = VARDIR/spool/exim_stage1
+never_users = root
+helo_allow_chars = _
+__IF_USE_SYSLOG__
+
+__INCLUDE__ stage1/force_disable_ipv6
+
+smtp_enforce_sync = __SMTP_ENFORCE_SYNC__
+smtp_accept_max_per_host = ${if match_ip{$sender_host_address}{+trusted_hosts}{__SMTP_ACCEPT_MAX_PER_TRUSTED_HOST__}{__SMTP_ACCEPT_MAX_PER_HOST__}}
+smtp_receive_timeout = __SMTP_RECEIVE_TIMEOUT__
+smtp_accept_max = __SMTP_ACCEPT_MAX__
+smtp_load_reserve = __SMTP_LOAD_RESERVE__
+deliver_queue_load_max = __SMTP_LOAD_RESERVE__
+smtp_accept_queue_per_connection = 1000
+smtp_accept_max_per_connection = __SMTP_ACCEPT_MAX_PER_CONNECTION__
+queue_run_max = 5
+
+__INCLUDE__ stage1/cluster_settings
+
+delay_warning = 4h:8h:24h
+delay_warning_condition = ${if or {\
+  { !eq{$h_list-id:$h_list-post:$h_list-subscribe:}{} }\
+  { match{$h_precedence:}{(?i)bulk|list|junk} }\
+  { match{$h_auto-submitted:}{(?i)auto-generated|auto-replied} }\
+  } {no}{yes}}
+
+host_lookup = *
+rfc1413_hosts =
+rfc1413_query_timeout = 0s
+acl_smtp_connect = acl_check_conn
+acl_smtp_rcpt = acl_check_rcpt
+acl_smtp_data = acl_check_data
+acl_smtp_helo = acl_check_helo
+acl_smtp_mail = acl_check_mail
+acl_smtp_mime = acl_check_mime
+ignore_bounce_errors_after = 0s
+
+__INCLUDE__ stage1/frozen_time
+
+message_size_limit = __GLOBAL_MAXMSGSIZE__
+accept_8bitmime = true
+allow_mx_to_ip = __ALLOW_MX_TO_IP__
+
+received_headers_max = __MAX_RECEIVED__
+received_header_text = "Received: \
+__IF__ MASKRELAY
+        ${if eq{$interface_port}{587}\
+          {from maskedhost [127.0.0.1]}\
+          { ${if def:sender_rcvhost {from ${sender_rcvhost}\n\t}\
+            {${if def:sender_ident {from ${sender_ident} }}\
+            ${if def:sender_helo_name {(helo=${sender_helo_name})\n\t}}}}\
+          } \
+         } \
+__ELSE__ MASKRELAY
+        ${if def:sender_rcvhost {from ${sender_rcvhost}\n\t}\
+        {${if def:sender_ident {from ${sender_ident} }}\
+        ${if def:sender_helo_name {(helo=${sender_helo_name})\n\t}}}}\
+__FI__
+         by $smtp_active_hostname stage1 \
+         ${if def:received_protocol {with ${received_protocol}}} \n\t\
+         (Exim MailCleaner) \n\t\
+         id ${message_id} ${if def:received_for {\n\tfor <$received_for>}} ${if def:sender_address {\n\tfrom <$sender_address>}}"
+
+domainlist local_domains =
+domainlist relay_to_domains = wildlsearch;VARDIR/spool/tmp/mailcleaner/domains.list
+domainlist domains_to_callout = VARDIR/spool/tmp/mailcleaner/domains_to_callout.list
+domainlist domains_to_extcallout = VARDIR/spool/tmp/mailcleaner/domains_to_extcallout.list
+domainlist domains_to_altcallout = lsearch;VARDIR/spool/tmp/mailcleaner/domains_to_altcallout.list
+domainlist domains_to_addlistcallout = VARDIR/spool/tmp/mailcleaner/domains_to_addlistcallout.list
+domainlist domains_to_adcheck = VARDIR/spool/tmp/mailcleaner/domains_to_adcheck.list
+domainlist domains_to_greylist = VARDIR/spool/tmp/mailcleaner/domains_to_greylist.list
+domainlist domains_to_avoid_greylist = VARDIR/spool/tmp/mailcleaner/domains_to_avoid_greylist.list
+domainlist domains_to_check_batv = lsearch;VARDIR/spool/tmp/mailcleaner/domains_to_check_batv.list
+domainlist domains_to_preventspoof = VARDIR/spool/tmp/mailcleaner/domains_to_prevent_spoof.list
+domainlist domains_require_tls_to = VARDIR/spool/tmp/mailcleaner/domains_require_tls_to.list
+domainlist domains_require_tls_from = VARDIR/spool/tmp/mailcleaner/domains_require_tls_from.list
+domainlist local_domains_require_incoming_tls = VARDIR/spool/tmp/mailcleaner/local_domains_require_incoming_tls.list
+domainlist local_domains_require_outgoing_tls = VARDIR/spool/tmp/mailcleaner/local_domains_require_outgoing_tls.list
+domainlist no_caps_domains = VARDIR/spool/tmp/mailcleaner/no_caps_domains.list
+
+hostlist   relay_from_hosts = <; 127.0.0.1 ; __RELAY_FROM_HOSTS__
+hostlist   trusted_hosts = <; +relay_from_hosts ; __TRUSTED_HOSTS__
+hostlist   html_ctrl_hosts = <; __HTML_CTRL_WL_HOSTS__
+hostlist   no_ratelimit_hosts = <; __NO_RATELIMIT_HOSTS__
+domainlist relayrefuseddomains = VARDIR/spool/tmp/exim/blacklists/relaytodomains
+RELAYDEST = VARDIR/spool/tmp/mailcleaner/relay_accepteddest.list
+
+#FULLWHITELIST
+addresslist full_whitelisted_senders = lsearch;VARDIR/spool/mailcleaner/full_whitelisted_senders.list
+
+smtp_accept_reserve = __SMTP_RESERVE__
+smtp_reserve_hosts = ${if eq{$interface_port}{587}{*}{+relay_from_hosts}}
+
+__IF__ DMARCREPORTING
+dmarc_history_file = VARDIR/spool/tmp/exim/dmarc.history
+__FI__
+dmarc_tld_file = SRCDIR/etc/rbls/effective_tlds.txt
+
+__INCLUDE__ stage1/ldap_callout
+
+STATSADD = ${readsocket{/var/mailcleaner/run/statsdaemon.sock}{ADD $acl_c8 1}{2s}{\n}{ \
+               ${run{/bin/sh -c 'echo "ADD $acl_c8 1" >> /tmp/missed_stats.${tod_logfile}'}{}{command failed}} \
+           }}
+perl_startup = do '__SRCDIR__/etc/exim/stage1_scripts.pl'
+
+######################################################################
+#                       ACL CONFIGURATION                            #
+#         Specifies access control lists for incoming SMTP mail      #
+######################################################################
+begin acl
+
+acl_check_conn:
+
+__IF__ RATELIMIT
+warn ratelimit          = __RATELIMIT_RULE__
+          !hosts        = <; 127.0.0.1 ; +trusted_hosts ; +no_ratelimit_hosts
+          log_message   = delaying fast sender: $sender_rate / $sender_rate_period
+          delay         = __RATELIMIT_DELAY__s
+          set acl_c8    = smtp:delayed:ratelimit
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:delayed
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - delayed connection, fast sender: $sender_rate / $sender_rate_period - smtp:dlyed,smtp:delayed:ratelimit
+ __FI__
+__FI__
+__IF__ TRUSTED_RATELIMIT
+warn ratelimit          = __TRUSTED_RATELIMIT_RULE__
+          hosts         = <; !no_ratelimit_hosts ; +trusted_hosts
+          log_message   = delaying fast sender: $sender_rate / $sender_rate_period
+          delay         = __TRUSTED_RATELIMIT_DELAY__s
+          set acl_c8    = smtp:delayed:ratelimit
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:delayed
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - delayed connection, trusted fast sender: $sender_rate / $sender_rate_period - smtp:delayed,smtp:delayed:ratelimit
+ __FI__
+__FI__
+
+
+__IF__ RBL
+  deny    !hosts        = <; 127.0.0.1 ; NORBLHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          dnslists      = __RBLS__
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          message = Blacklisted in ${perl{hideToken}{$dnslist_domain}}: $dnslist_text
+          log_message = "listed in ${perl{hideToken}{$dnslist_domain}}: $dnslist_text"
+          delay = __RBLTIMEOUT__s
+          set acl_c8    = smtp:refused:rbl
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:dnslist
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:dnslist:$dnslist_domain
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused connection, listed in $dnslist_domain : $dnslist_text - smtp:refused,smtp:refused:rbl
+ __FI__
+__FI__
+
+  deny    hosts         = HOSTBLACKLIST
+          !hosts        = <; 127.0.0.1 
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          message       = blacklisted host: $sender_host_address
+          set acl_c8    = smtp:refused:host_blacklist
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused connection, blacklisted host: $sender_host_address - smtp:refused,smtp:refused:host_blacklist
+ __FI__
+
+  accept  hosts = <; __SMTP_CONN_ACCESS__ ; 127.0.0.1
+
+acl_check_helo:
+  deny    condition     = ${if eq {$sender_helo_name}{ylmf-pc} {yes}{no}}
+          !hosts        = <; 127.0.0.1
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          log_message   = HELO/EHLO blocked
+          message       = HELO/EHLO blocked
+          set acl_c8    = smtp:refused:bad_helo
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, bad helo - smtp:refused,smtp:refused:bad_helo
+ __FI__
+    accept hosts        = *
+
+acl_check_mail:
+  # deny if no HELO command given
+  deny
+    condition = ${if def:sender_helo_name {no}{yes}}
+    delay = 10s
+    message = no HELO given before MAIL command
+
+    accept
+
+acl_check_rcpt:
+
+# FULLWHITELIST
+  accept
+          hosts         = +trusted_hosts
+          senders       = +full_whitelisted_senders
+
+  accept  hosts = <; ;
+  deny    !domains      = +relay_to_domains
+          !hosts        = <; +relay_from_hosts
+          !authenticated = *
+          message       = relay not permitted
+          log_message   = relay not permitted
+          set acl_c8    = smtp:refused:relay
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, relay not permitted - smtp:refused,smtp:refused:relay
+ __FI__
+
+  deny    domains       = +local_domains
+          local_parts   = ^[.] : ^.*[@%!/|]
+          set acl_c8    = smtp:refused:bad_local_part1
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, bad local part 1 - smtp:refused,smtp:refused:bad_local_part1
+ __FI__
+  deny    domains       = !+local_domains
+          local_parts   = ^[./|] : ^.*[@%!] : ^.*/\\.\\./
+          set acl_c8    = smtp:refused:bad_local_part2
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, bad local part 2 - smtp:refused,smtp:refused:bad_local_part2
+ __FI__
+
+  deny    domains       = +no_caps_domains
+          condition     = ${perl{no_caps_in_domain}{$sender_address_domain}}
+          message       = This domain does not accept sender addresses using capital letters
+          set acl_c8    = smtp:refused:refused_nonbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused_nonbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, $sender_address_domain contains capital letters
+ __FI__
+
+__IF__ __LISTS_PER_DOMAIN__
+  warn    set acl_m0    = ${perl{SMTP_WL_IP_Dom}{$domain}{$sender_host_address}}
+  warn    set acl_m1    = ${perl{SpamC_WL_IP_Dom}{$domain}{$sender_host_address}}
+__FI__
+  __INCLUDE__ stage1/remove_headers
+__IF__ __LISTS_PER_DOMAIN__
+  warn    condition    = ${if eq{$acl_m1}{true}{yes}{no}}
+          add_header    = X-MailCleaner-White-IP-DOM: WhIPDom
+__FI__
+  warn    hosts         = <; +trusted_hosts
+          add_header    = X-MailCleaner-TrustedIPs: Ok
+  warn    hosts         = <; +html_ctrl_hosts
+          add_header    = X-MailCleaner-HTML-WL: Ok
+  warn    spf           = pass
+          add_header    = :after_received:X-MailCleaner-SPF: $spf_result
+          set acl_m_checkspf = $spf_result
+  warn    !spf          = pass
+          !hosts        = <; +relay_from_hosts ; NOSPFDMARCHOSTS
+          !authenticated = *
+          add_header    = :after_received:X-MailCleaner-SPF: $spf_result
+  warn    !spf          = pass
+          hosts         = NOSPFDMARCHOSTS
+          remove_header = X-MailCleaner-SPF
+          add_header    = :after_received:X-MailCleaner-SPF: whitelisted (was $spf_result)
+  deny    message       = This domain does not accept unsigned bounces.
+          senders       = :
+          domains       = +domains_to_check_batv
+          condition     = ${if eq {${prvscheck {$local_part@$domain}{''}{1}}}{}}
+          set acl_c8    = smtp:refused:refused_nonbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused_nonbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, no BATV signature - smtp:refused,smtp:refused:refused_nonbatv
+ __FI__
+  deny    message       = Invalid reverse path signature.
+          senders       = :
+          domains       = +domains_to_check_batv
+          condition     = ${prvscheck {$local_part@$domain} {${lookup {$domain} lsearch {VARDIR/spool/tmp/mailcleaner/domains_to_check_batv.list}}} {1}}
+          !condition    = $prvscheck_result
+          set acl_c8    = smtp:refused:refused_badbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused_badbatv
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, bad BATV signature - smtp:refused,smtp:refused:refused_badbatv
+ __FI__
+
+  accept  local_parts   = mailcleaner_address_list
+          domains       = +domains_to_addlistcallout
+          message       = accepting and processing address list message
+          condition     = ${if exists{ADDRESSESDIR/${domain_data}.posters} {yes}{no} }
+          hosts         = ADDRESSESDIR/${domain_data}.posters
+ __IF__ DEBUG
+          logwrite      = DEBUG - accepted, address list submission
+ __FI__
+  deny    senders       = SENDERBLACKLIST
+          message       = blacklisted sender: $sender_address
+          set acl_c8    = smtp:refused:sender_blacklist
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, blacklisted sender: $sender_address - smtp:refused,smtp:refused:sender_blacklist
+ __FI__
+  deny    condition     = ${if exists{RECIPIENTBLACKLIST} {yes}{no} }
+          message       = blacklisted recipient: $local_part@$domain
+          recipients    = RECIPIENTBLACKLIST
+          set acl_c8    = smtp:refused:recipient_blacklist
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, blacklisted recipient: $local_part@$domain - smtp:refused,smtp:refused:recipient_blacklist
+ __FI__
+  deny    authenticated  =  *
+          condition      =  ${lookup{$authenticated_id}wildlsearch{USERBLACKLIST}{true}{false}}
+          message        = refused user due to massive abuse
+          log_message    = refused user due to massive abuse
+          set acl_c8    = smtp:refused:user_blacklist
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, blacklisted user: $authenticated_id - smtp:refused,smtp:refused:user_blacklist
+ __FI__
+
+
+  deny    domains       = +domains_to_preventspoof
+          !authenticated = *
+          !hosts        = <; NORBLHOSTS; NOSPFDMARCHOSTS; +relay_from_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          condition     = ${perl{prevent_domain_from}{$domain}{$sender_address_domain}}
+	  !spf		= pass
+          message       = This domain does not accept mail from itself (spoofing)
+          set acl_c8    = smtp:refused:refused_spoofing
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused_spoofing
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, spoofing attempt $sender_address ($domain) - smtp:refused,smtp:refused:refused_spoofing
+ __FI__
+
+  warn    condition     = ${if and{{def:sender_host_address}{!def:sender_host_name}}{yes}{no}}
+          !authenticated = *
+          add_header    = X-MailCleaner-RDNS: invalid reverse DNS for $sender_host_address
+          logwrite      = Invalid reverse DNS for $sender_host_address (port $received_port)
+
+__IF__ REJECTBADRDNS
+  deny    !hosts        = <; 127.0.0.1 ; NORBLHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          condition     = ${if and{{def:sender_host_address}{!def:sender_host_name}}{yes}{no}}
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          !authenticated = *
+          message       = Reverse DNS lookup failed for $sender_host_address
+          set acl_c8    = smtp:refused:badrdns
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:badrdns
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, bad reverse DNS for $sender_host_address ($domain) - smtp:refused,smtp:refused:refused_badrdns
+ __FI__
+__FI__
+
+  deny    domains       = +domains_to_addlistcallout
+          condition     = ${if exists{ADDRESSESDIR/${domain_data}.addresslist} {yes}{no} }
+          local_parts   = !ADDRESSESDIR/${domain_data}.addresslist
+          recipients    = !lsearch{ADDRESSESDIR/${domain_data}.addresslist}
+          message       = No such user
+          set acl_c8    = smtp:refused:callout
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:callout_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, callout refused (addlist): $local_part@$domain - smtp:refused,smtp:refused:callout
+ __FI__
+
+ __INCLUDE__ stage1/acl_cluster_settings
+
+  deny    domains       = +domains_to_callout : +domains_to_altcallout
+          !verify       = recipient/callout=__CALLOUT_TIMEOUT__s,defer_ok
+          set acl_c8    = smtp:refused:callout
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:callout_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, callout refused (SMTP): $local_part@$domain - smtp:refused,smtp:refused:callout
+ __FI__
+
+  deny    domains       = +domains_to_extcallout
+          set   acl_c0  = ${perl{external_callout_verify}{$local_part}{$domain}}
+          !condition    = ${extract{result}{$acl_c0}}
+          message       = 550 Callout verification failed: ${extract{message}{$acl_c0}}
+          log_message   = external callout failed: ${extract{message}{$acl_c0}}
+          set acl_c8    = smtp:refused:callout
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:callout_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, external callout failed: ${extract{message}{$acl_c0}} - smtp:refused,smtp:refused:callout
+ __FI__
+
+
+__IF__ SENDERVERIFY
+  deny    !verify       = sender
+
+__INCLUDE__ stage1/sender_verify_wl
+
+          set acl_c8    = smtp:refused:sender_verify
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:sender_verify_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, sender verify failed for $sender_address - smtp:refused,smtp:refused:sender_verify
+ __FI__
+__FI__
+
+__IF__ RCPTRBL
+  deny    !hosts        = <; 127.0.0.1 ; NORBLHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          dnslists = __RBLS__
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          message = Blacklisted in ${perl{hideToken}{$dnslist_domain}}: $dnslist_text
+          log_message   = "listed in ${perl{hideToken}{$dnslist_domain}} : $dnslist_text"
+          delay = __RBLTIMEOUT__s
+          set acl_c8    = smtp:refused:rbl
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:rbl_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = user:$domain:$local_part:rbl_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:dnslist:$dnslist_domain
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, listed in rbl ($dnslist_domain : $dnslist_text) - smtp:refused,smtp:refused:rbl
+ __FI__
+__FI__
+
+__IF__ BSRBL
+  deny    senders = :
+          !hosts        = <; 127.0.0.1 ; NORBLHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          !spf          = pass
+          dnslists      = __BSRBLS__
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          message       =  backscatterer blacklisted: $dnslist_text
+          log_message   = "backscatterer listed: $dnslist_text"
+          delay         = __RBLTIMEOUT__s
+          set acl_c8    = smtp:refused:backscatter
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:brbl_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = user:$domain:$local_part:brbl_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:dnslist:$dnslist_domain
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, listed as backscatterrer ($dnslist_text) - smtp:refused,smtp:refused:backscatter
+ __FI__
+__FI__
+__IF__ REJECTBADSPF
+  deny    !hosts        = <; 127.0.0.1 ; NORBLHOSTS ; NOSPFDMARCHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          !condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          spf           = fail
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          message       = $sender_host_address is not allowed to send mail from ${if eq {$sender_address_domain}{} {(helo)$sender_helo_name}{$sender_address_domain}} (SPF failure)
+          set acl_c8    = smtp:refused:badspf
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:badspf
+          set acl_c9    = STATSADD
+          set acl_c8    = user:$domain:$local_part:badspf
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, $sender_host_address is not allowed to send mail from $sender_address_domain (SPF failure) - smtp:refused,smtp:refused:badspf
+ __FI__
+__FI__
+
+.include_if_exists  VARDIR/spool/tmp/exim_stage1/blacklists/ip-domain
+
+ defer
+          !spf          = pass
+          message       = $sender_host_address is not yet authorized to deliver \
+                          mail from <$sender_address> to <$local_part@$domain>. \
+                          Please try later.
+          log_message   = greylisted (spf: $spf_result)
+          domains       = +domains_to_greylist
+          !senders      = :
+          condition     = ${if !def:acl_c1}
+          condition     = ${if eq {$received_port}{587} {0}{1}}
+          !hosts        = <; +trusted_hosts ; \
+                            ${if exists {__SRCDIR__/etc/greylistd/whitelist-hosts}\
+                               {__SRCDIR__/etc/greylistd/whitelist-hosts}{}} ; \
+                            ${if exists {__VARDIR__/spool/greylistd/whitelist-hosts}\
+                               {__VARDIR__/spool/greylistd/whitelist-hosts}{}}
+          !sender_domains = +domains_to_avoid_greylist
+          condition     = ${readsocket{__VARDIR__/run/greylistd/socket}\
+                                 {--grey \
+                                  $sender_host_address \
+                                  $sender_address \
+                                  $local_part@$domain}\
+                                 {5s}{}{false}}
+          set acl_c8    = smtp:delayed:greylist
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:greylisted
+          set acl_c9    = STATSADD
+          set acl_c8    = user:$domain:$local_part:greylisted
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:delayed
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:delayed
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - delayed, greylisted - smtp:delayed,smtp:delayed:greylist
+ __FI__
+
+  deny    !authenticated = *
+          !hosts        = +relay_from_hosts
+          condition     = ${if eq {$received_port}{587} {1}{0}}
+          message       = unauthenticated session on submission port
+          log_message   = refusing unauthenticated session on submission port
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused:unauthenticated
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, not authenticated - smtp:refused,smtp:refused:unauthenticated
+ __FI__
+
+__IF__ USETLS
+  deny    hosts         = <; __HOSTS_REQUIRE_INCOMING_TLS__
+          !encrypted    = *
+          message       = Encryption is required from you
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused:unencrypted
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, not encrypted - smtp:refused,smtp:refused:unencrypted
+ __FI__
+
+  deny    domains       = +local_domains_require_incoming_tls
+          !encrypted    = *
+          message       = Encryption is required to this domain
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused:unencrypted
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, only encrypted sessions accepted for this domain - smtp:refused,smtp:refused:unencrypted
+ __FI__
+
+  deny    !encrypted    = *
+          condition     = ${if match_domain{$sender_address_domain}{+domains_require_tls_from}}
+          message       = Encryption is required from your domain
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused:unencrypted
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, not encrypted from required domain - smtp:refused,smtp:refused:unencrypted
+ __FI__
+__FI__
+
+.include_if_exists  VARDIR/spool/tmp/exim_stage1/custom_acl_encryption
+
+__INCLUDE__ stage1/recipient_verification
+
+  warn    domains       = +relay_to_domains
+          hosts         = <; 127.0.0.1 ; NORBLHOSTS ; NOSPFDMARCHOSTS ; +trusted_hosts
+__IF__ __LISTS_PER_DOMAIN__
+          condition    = ${if eq{$acl_m0}{true}{yes}{no}}
+__FI__
+          control       = dmarc_disable_verify
+ __IF__ DEBUG
+          logwrite      = DMARC DEBUG: disabling dmarc from $sender_host_address, sender $sender_address
+ __FI__
+
+ warn    set acl_m4    = 0
+ warn    domains       = +domains_to_adcheck
+         log_message   = Doing LDAP verification for $local_part@$domain ([$sender_host_address] $sender_address)
+ warn    domains       = +domains_to_adcheck
+         condition     = ${lookup ldap {LDAP_AD_MAIL_RCPT} {false}{true}}
+         set acl_m4    = 1
+
+ deny    domains       = +domains_to_adcheck
+         condition     = ${acl_m4}
+         message       = User unknown
+         log_message   = LDAP verification failed for $local_part@$domain
+         set acl_c8    = smtp:refused:callout
+         set acl_c9    = STATSADD
+         set acl_c8    = domain:$domain:callout_refused
+         set acl_c9    = STATSADD
+         set acl_c8    = smtp:refused
+         set acl_c9    = STATSADD
+         set acl_c8    = domain:$domain:refused
+         set acl_c9    = STATSADD
+ __IF__ DEBUG
+         logwrite      = DEBUG - refused, invalid recipient (LDAP): $local_part@$domain- smtp:refused,smtp:refused:callout
+ __FI__
+
+ warn	 authenticated = *
+         set   acl_c1  = authenticated
+
+ accept  domains       = +relay_to_domains
+         verify        = recipient
+ __IF__ DEBUG
+          logwrite      = DEBUG - accepted, valid recipient: $local_part@$domain
+ __FI__
+
+  deny    domains       = +relayrefuseddomains
+          !recipients   = RELAYDEST
+          message       = Relaying to this domain is forbidden
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused:domain
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, forbidden destination domain - smtp:refused,smtp:refused:domain
+ __FI__
+  accept  hosts         = +relay_from_hosts
+__IF__ PREVENTRELAYFROMUNKNOWNDOMAIN
+          sender_domains= : +relay_to_domains
+__FI__
+          set   acl_c0  = relayed
+          set acl_c8    = smtp:relayed:host
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:relayed
+          set acl_c9    = STATSADD
+          logwrite      = Accepting authorized relaying session from $sender_host_address, sender $sender_address on port $received_port
+ __IF__ DEBUG
+          logwrite      = DEBUG - accepted relay, by host - smtp:relayd,smtp:relayed:host
+ __FI__
+  accept  authenticated = *
+__IF__ PREVENTRELAYFROMUNKNOWNDOMAIN
+          sender_domains= : +relay_to_domains
+__FI__
+          set   acl_c0  = relayed
+          set acl_c8    = smtp:relayed:authenticated
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:relayed
+          set acl_c9    = STATSADD
+          logwrite      = Accepting authenticated session from $sender_host_address, sender $sender_address on port $received_port
+ __IF__ DEBUG
+          logwrite      = DEBUG - accepted relay, authentified - smtp:relayed,smtp:relayed:authenticated
+ __FI__
+
+  deny    domains       = +relay_to_domains
+          message       = User unknown
+          set acl_c8    = smtp:refused:callout
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:callout_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, invalid recipient: $local_part@$domain- smtp:refused,smtp:refused:callout
+ __FI__
+
+  deny    message       = relay not permitted
+          set acl_c8    = smtp:refused:relay
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, relay not permitted - smtp:refused,smtp:refused:relay
+ __FI__
+
+acl_check_mime:
+
+# FULLWHITELIST
+  accept  hosts         = +trusted_hosts
+          senders       = +full_whitelisted_senders
+
+__IF__ LOG_ATTACHMENTS
+  warn  condition       = ${if def:mime_filename {true}{false}}
+        logwrite        = Attachment: $mime_filename
+__FI__
+
+  ## Block .js and .jse in attachments and in zip/rar
+  deny	message = Detected forbidden filetype (Security reasons).
+	log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+	condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-jsinzip}{true}{false}}
+	condition = ${if match{$mime_filename}{\N(?i)\.(zip|rar)$\N}}
+	decode = default
+	condition = ${if match{${run{/usr/bin/unzip -l \
+				$mime_decoded_filename}}}\
+				{\N(?i)\.(js|jse)\n\N}}
+	set acl_c8    = smtp:relayed:virus
+	set acl_c9    = STATSADD
+	set acl_c8    = smtp:relayed:refused
+	set acl_c9    = STATSADD
+
+  deny	message = Detected forbidden filetype (Security reasons).
+	log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+	condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-jsinzip}{true}{false}}
+	condition = ${if match{$mime_filename}{\N(?i)\.(rar|zip)$\N}}
+	decode = default
+	condition = ${if match{${run{/usr/bin/rar lb \
+				$mime_decoded_filename}}}\
+				{\N(?i)\.(js|jse)\n\N}}
+	set acl_c8    = smtp:relayed:virus
+	set acl_c9    = STATSADD
+	set acl_c8    = smtp:relayed:refused
+	set acl_c9    = STATSADD
+
+  deny message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-jsinzip}{true}{false}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(js|jse)$\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  ## Block .docm and .dotm in attachments and in zip/rar
+  deny  message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-docm}{true}{false}}
+	condition = ${if ! match_domain {${domain:${address:$header_to:}}}{VARDIR/spool/tmp/mailcleaner/domains_to_prevent_docm.list}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(zip|rar)$\N}}
+        decode = default
+        condition = ${if match{${run{/usr/bin/unzip -l \
+                                $mime_decoded_filename}}}\
+                                {\N(?i)\.(docm|dotm)\n\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  deny  message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-docm}{true}{false}}
+	condition = ${if ! match_domain {${domain:${address:$header_to:}}}{VARDIR/spool/tmp/mailcleaner/domains_to_prevent_docm.list}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(rar|zip)$\N}}
+        decode = default
+        condition = ${if match{${run{/usr/bin/rar lb \
+                                $mime_decoded_filename}}}\
+                                {\N(?i)\.(docm|dotm)\n\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  deny message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-docm}{true}{false}}
+	condition = ${if ! match_domain {${domain:${address:$header_to:}}}{VARDIR/spool/tmp/mailcleaner/domains_to_prevent_docm.list}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(docm|dotm)$\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  ## Block .wsf in attachments and in zip/rar
+  deny  message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-wsf}{true}{false}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(zip|rar)$\N}}
+        decode = default
+        condition = ${if match{${run{/usr/bin/unzip -l \
+                                $mime_decoded_filename}}}\
+                                {\N(?i)\.(wsf)\n\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  deny  message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-wsf}{true}{false}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(rar|zip)$\N}}
+        decode = default
+        condition = ${if match{${run{/usr/bin/rar lb \
+                                $mime_decoded_filename}}}\
+                                {\N(?i)\.(wsf)\n\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  deny message = Detected forbidden filetype (Security reasons).
+        log_message = Detected forbidden filetype (Security reasons): filename=$mime_filename, recipients=$recipients.
+        condition = ${if exists{/var/mailcleaner/spool/mailcleaner/mc-experimental-wsf}{true}{false}}
+        condition = ${if match{$mime_filename}{\N(?i)\.(wsf)$\N}}
+        set acl_c8    = smtp:relayed:virus
+        set acl_c9    = STATSADD
+        set acl_c8    = smtp:relayed:refused
+        set acl_c9    = STATSADD
+
+  accept
+
+acl_check_data:
+
+# FULLWHITELIST
+  accept  remove_header = X-MailCleaner-FullWhitelist
+          remove_header = X-Newsl
+          hosts         = +trusted_hosts
+          senders       = +full_whitelisted_senders
+
+__IF__ OUTGOINGVIRUSSCAN
+  deny    message =  This message contains malware ($malware_name)
+          condition = ${if eq {$acl_c0}{relayed} {1}{0}}
+          malware = ${if eq {$acl_c0}{relayed} {1}{0}}/defer_ok
+          set acl_c8    = smtp:relayed:virus
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:relayed:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused relay, virus detected - smtp:relayed:virus,smtp:relayed:refused
+ __FI__
+__FI__
+
+  warn    dmarc_status   = accept : none : off
+          !authenticated = *
+ __IF__ DEBUG
+          log_message    = DMARC DEBUG: $dmarc_status $dmarc_used_domain
+ __FI__
+          add_header     = :at_start:${authresults {$primary_hostname}}
+
+
+  warn    dmarc_status   = quarantine
+          !authenticated = *
+          add_header     = X-MailCleaner-DMARC: quarantine
+          log_message    = Message from $dmarc_used_domain failed sender's DMARC policy, should quarantine.
+
+__IF__ REJECTDMARC
+  deny    dmarc_status   = reject
+          !authenticated = *
+          message       = Message from $dmarc_used_domain failed sender's DMARC policy, rejecting.
+          set acl_c8    = smtp:refused:dmarc
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:dmarc_refused
+          set acl_c9    = STATSADD
+          set acl_c8    = smtp:refused
+          set acl_c9    = STATSADD
+          set acl_c8    = domain:$domain:refused
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - refused, message from $dmarc_used_domain failed sender's DMARC policy.
+ __FI__
+__ELSE__ REJECTDMARC
+  warn    dmarc_status   = reject
+          !authenticated = *
+          add_header     = X-MailCleaner-DMARC: reject
+          log_message    = Message from $dmarc_used_domain failed sender's DMARC policy, should reject.
+__FI__
+
+  warn    !hosts        = <; +relay_from_hosts
+          !authenticated = *
+          add_header = :after_received:X-MailCleaner-recipients: $recipients
+          add_header = :after_received:X-MailCleaner-sender_address: $sender_address
+          add_header = :after_received:X-MailCleaner-return_path: $return_path
+
+  accept  set acl_c8    = smtp:accepted
+          set acl_c9    = STATSADD
+ __IF__ DEBUG
+          logwrite      = DEBUG - accepted data, final acceptance - smtp:accepted
+ __FI__
+
+######################################################################
+#                      ROUTERS CONFIGURATION                         #
+#               Specifies how addresses are handled                  #
+######################################################################
+begin routers
+
+.include_if_exists SRCDIR/etc/exim/mc_binary/mc_router
+
+# FULLWHITELIST
+full_whitelist:
+  driver     = accept
+  transport  = bypass_full_whitelist
+  condition  = ${if match_ip{$sender_host_address}{+trusted_hosts} {yes}}
+  senders    = +full_whitelisted_senders
+  headers_add = X-MailCleaner-FullWhitelist: fully whitelisted
+
+batv_redirect:
+  driver = redirect
+  domains = +domains_to_check_batv
+  data = ${prvscheck {$local_part@$domain} {${lookup {$domain} lsearch {VARDIR/spool/tmp/mailcleaner/domains_to_check_batv.list}}} }
+
+send_to_smart_host:
+  driver = manualroute
+  transport = remote_smtp
+  domains = !+relay_to_domains
+  route_data = ${lookup{${domain:$h_From:}}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains_smarthost.list}}
+
+__INCLUDE__ stage1/routers_cluster_settings
+
+bypass_router:
+  driver = manualroute
+  transport = bypass_smtp
+  domains = +relay_to_domains
+  local_parts = ${if exists{BYPASSDIR/${domain_data}} {nwildlsearch;BYPASSDIR/${domain_data}} {} }
+  self = send
+  headers_add = X-MailCleaner: bypassed
+  route_list = * 127.0.0.1 byname
+  no_verify
+
+alternat_callout_router:
+  driver = manualroute
+  pass_router = filter_forward
+  domains = +domains_to_altcallout
+  transport = callout_transport
+  route_data = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains_to_altcallout.list}}
+  verify_only
+
+callout_router:
+  driver = manualroute
+  pass_router = filter_forward
+  domains = !+domains_to_altcallout : +domains_to_callout
+  transport = callout_transport
+  route_data = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains.list}}
+  verify_only
+
+address_list_router:
+  driver = accept
+  local_parts = mailcleaner_address_list
+  domains = +domains_to_addlistcallout
+  condition = ${if exists{ADDRESSESDIR/${domain_data}.posters} {yes}{no} }
+  transport = address_list_transport
+
+copyto_route:
+  debug_print = "R: copyto_route for ${sender_address}"
+  driver = redirect
+  check_ancestor
+  qualify_preserve_domain
+  headers_add = X-MailCleaner-CopyTo: this is a message copy (original sender: ${sender_address})
+  data = ${if and{ \
+               {!eq {$sender_address}{}} \
+               {or {\
+                 {eq {$acl_c0}{relayed}} \
+                 {eq {$acl_c1}{authenticated}} \
+               }}\
+               {exists{COPYTODIR/${sender_address_domain}}} \
+              }\
+              {${lookup{$sender_address_local_part}nwildlsearch{COPYTODIR/${sender_address_domain}}}} \
+              {} }
+  unseen
+  repeat_use = false
+  no_verify
+
+__IF__ USEARCHIVER
+archiver_route:
+  debug_print = "R: archiver_route for $domain"
+  driver = manualroute
+  condition = ${if def:header_MailCleaner-CopyTo:{0}{1}}
+  senders = ${if and{ \
+                 {exists{ARCHIVERDIR/${sender_address_domain}}} \
+                 {!eq {$sender_address}{}} \
+                 {or {\
+                     {eq {$acl_c0}{relayed}} \
+                     {eq {$acl_c1}{authenticated}} \
+                 }}\
+                 } {nwildlsearch;ARCHIVERDIR/${sender_address_domain}} {} }
+  transport = archiver_smtp_transport
+  route_list = * __ARCHIVER_HOST__
+  self = send
+  unseen
+  no_verify
+__FI__
+
+toenginefilter_forward:
+  driver = accept
+  transport = to_engine
+  domains = +relay_to_domains
+  headers_remove = X-MailCleaner:X-MailCleaner-Forced
+  condition = ${if exists{VARDIR/spool/tmp/mailcleaner/exim_nostage2}{yes}{no}}
+  no_verify
+
+filter_forward:
+  driver = manualroute
+  transport = local_smtp
+  domains = +relay_to_domains
+  #domains = ! +local_domains  ->  to filter outgoing smtp traffic too; otherwise it goes out by next router (dnslookup)
+  self = send
+  route_list = * 127.0.0.1 byname
+  headers_remove = X-MailCleaner:X-MailCleaner-Forced
+__INCLUDE__ stage1/filter_forward
+
+dnslookup_freeze:
+  driver = redirect
+  senders = FROZENSENDERS
+  user = mailcleaner
+  allow_filter
+  allow_freeze
+  data = "#Exim filter \n freeze"
+
+dnslookup_gateway:
+  driver = manualroute
+  domains = ! +local_domains : ! +relay_to_domains
+  condition = ${if exists{VARDIR/spool/mailcleaner/smtp_proxy.conf}{yes}{no}}
+  transport = remote_smtp
+  route_list = wildlsearch;;VARDIR/spool/mailcleaner/smtp_proxy.conf $value
+  ignore_target_hosts = <; 0.0.0.0 ; 127.0.0.0/8
+
+dnslookup:
+  driver = dnslookup
+  domains = ! +local_domains : ! +relay_to_domains
+  transport = remote_smtp
+  ignore_target_hosts = <; 0.0.0.0 ; 127.0.0.0/8
+  no_more
+
+__INCLUDE__ stage1/routers
+
+######################################################################
+#                      TRANSPORTS CONFIGURATION                      #
+######################################################################
+begin transports
+
+.include_if_exists SRCDIR/etc/exim/mc_binary/mc_transport
+
+# FULLWHITELIST
+bypass_full_whitelist:
+  driver = smtp
+  helo_data = __HELO_NAME__
+  allow_localhost = true
+  hosts = localhost
+  interface = 127.0.0.1
+  port = 2525
+
+bypass_smtp:
+  driver = smtp
+  helo_data = __HELO_NAME__
+  allow_localhost = true
+  hosts = localhost
+  interface = 127.0.0.1
+  port = 2525
+  hosts_try_chunking =
+  return_path = ${if and { \
+                             {def:return_path} \
+                             {match_domain{${domain:$return_path}}{+domains_to_check_batv}} \
+                             {! eq{${prvscheck {$return_path} {}}} {} } \
+                         } \
+                     {${prvscheck {$return_path} {}}} \
+                     {$return_path} \
+                 }
+
+to_engine:
+  driver = appendfile
+  user = mailcleaner
+  group = mailcleaner
+  mode = 640
+  mailstore_format
+  create_directory = true
+  directory = VARDIR/spool/exim_stage2/input
+  mailstore_prefix = "${message_id}\n${caller_uid} ${caller_gid}\n${sender_host_address}\n${received_time}\n${max_received_linelength}\n${body_linecount}\n"
+  mailstore_suffix = "\n${message_headers_raw}"
+  batch_max = 200
+
+local_smtp:
+  driver = smtp
+  helo_data = __HELO_NAME__
+  allow_localhost = true
+  hosts = localhost
+  interface = 127.0.0.1
+  port = 2424
+  return_path = ${if and { \
+                             {def:return_path} \
+                             {match_domain{${domain:$return_path}}{+domains_to_check_batv}} \
+                             {! eq{${prvscheck {$return_path} {}}} {} } \
+                         } \
+                     {${prvscheck {$return_path} {}}} \
+                     {$return_path} \
+                 }
+  dkim_domain = ${if or{\
+                         {! eq{$sender_host_authenticated}{}}\
+                         { match_ip{$sender_host_address}{+relay_from_hosts} }\
+                       }\
+                   {${extract {1}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}}\
+                   {}\
+                 }
+  dkim_selector = ${extract {2}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}
+  dkim_private_key = ${if exists {VARDIR/spool/tmp/mailcleaner/dkim/${domain_data:$return_path}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/${domain_data:$return_path}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/default.pkey} \
+                      }
+  hosts_avoid_tls = localhost
+  hosts_try_chunking =
+
+remote_smtp:
+  driver = smtp
+__IF__ MASQUERADE_OUTGOING_HELO
+  helo_data = ${if def:sender_address_domain {$sender_address_domain}{__HELO_NAME__}}
+__ELSE__ MASQUERADE_OUTGOING_HELO
+  helo_data = __HELO_NAME__
+__FI__
+  multi_domain = false
+  max_rcpt = __MAX_RCPT__
+  final_timeout = 120s
+  data_timeout = 120s
+  connect_timeout = 30s
+  hosts_try_chunking =
+__IF__ USETLS
+  hosts_require_tls = <; ${if match_domain{$domain}{+domains_require_tls_to:+local_domains_require_outgoing_tls} {*}{__HOSTS_REQUIRE_TLS__} }
+__FI__
+  return_path = ${if and { \
+                             {def:return_path} \
+                             {match_domain{${domain:$return_path}}{+domains_to_check_batv}} \
+                         } \
+                     {${prvs {$return_path} {${lookup {${domain:$return_path}} lsearch {VARDIR/spool/tmp/mailcleaner/domains_to_check_batv.list}}}}} \
+                     {$return_path} \
+                 }
+  dkim_domain = ${extract {1}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}
+  dkim_selector = ${extract {2}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}
+  dkim_private_key = ${if exists {VARDIR/spool/tmp/mailcleaner/dkim/${domain_data:$return_path}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/${domain_data:$return_path}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/default.pkey} \
+                      }
+
+callout_transport:
+  driver = smtp
+  helo_data = __HELO_NAME__
+  multi_domain = false
+  hosts_try_chunking =
+
+archiver_smtp_transport:
+  debug_print = "T: archiving mail for $local_part@$domain"
+  driver = smtp
+  helo_data = __HELO_NAME__
+  port = __ARCHIVER_PORT__
+  allow_localhost
+__IF__ USETLS
+  hosts_require_tls = <; __HOSTS_REQUIRE_TLS__
+__FI__
+  hosts_try_chunking =
+
+address_list_transport:
+  driver = pipe
+  command = SRCDIR/etc/exim/address_list.pl ${domain} ${sender_address} ${local_part}@${domain}
+  user = mailcleaner
+  group = mailcleaner
+  timeout = 10m
+  log_output = true
+
+__INCLUDE__ stage1/transports
+
+######################################################################
+#                      RETRY CONFIGURATION                           #
+######################################################################
+begin retry
+
+# Domain               Error       Retries
+# ------               -----       -------
+
+*                      tls_required
+*                      *           __RETRY_RULE__
+
+######################################################################
+#                      REWRITE CONFIGURATION                         #
+######################################################################
+
+__INCLUDE__ stage1/rewrite_configuration
+
+######################################################################
+#                   AUTHENTICATION CONFIGURATION                     #
+######################################################################
+begin authenticators
+
+fixed_plain:
+  driver = plaintext
+  public_name = PLAIN
+  server_condition = ${perl{authenticate}{$2}{$3}}
+  server_set_id = $2
+__IF__ FORBIDCLEARAUTH
+  client_condition = ${if !eq{$tls_cipher}{}}
+  server_advertise_condition = ${if eq{$tls_cipher}{}{no}{yes}}
+__FI__
+
+fixed_login:
+   driver = plaintext
+   public_name = LOGIN
+   server_prompts = "Username:: : Password::"
+   server_condition = ${perl{authenticate}{$1}{$2}}
+   server_set_id = $1
+__IF__ FORBIDCLEARAUTH
+   client_condition = ${if !eq{$tls_cipher}{}}
+   server_advertise_condition = ${if eq{$tls_cipher}{}{no}{yes}}
+__FI__

--- a/etc/exim/exim_stage4.conf_template_4.94
+++ b/etc/exim/exim_stage4.conf_template_4.94
@@ -1,0 +1,387 @@
+######################################################################
+#                    MAIN CONFIGURATION SETTINGS                     #
+######################################################################
+
+VARDIR = __VARDIR__
+SRCDIR = __SRCDIR__
+
+ARCHIVERDIR = VARDIR/spool/tmp/exim_stage1/archiver
+COPYTODIR = VARDIR/spool/tmp/exim_stage1/copyto
+
+hide mysql_servers = localhost::(VARDIR/run/mysql_slave/mysqld.sock)/mc_config/mailcleaner/__DBPASSWD__
+
+primary_hostname = mailcleaner
+qualify_domain = __HELO_NAME__
+smtp_active_hostname = __HELO_NAME__
+smtp_banner = __SMTP_BANNER__
+__IF__ ERRORS_REPLY_TO
+errors_reply_to = __ERRORS_REPLY_TO__
+__FI__
+
+log_selector = +smtp_confirmation +delivery_size
+message_logs = true
+exim_user = mailcleaner
+exim_group = mailcleaner
+log_file_path = __IF_USE_SYSLOGENABLED__ VARDIR/log/exim_stage4/%slog
+pid_file_path = VARDIR/run/exim_stage4.pid
+spool_directory = VARDIR/spool/exim_stage4
+never_users = root
+__IF_USE_SYSLOG__
+
+host_lookup =
+rfc1413_hosts =
+rfc1413_query_timeout = 0s
+acl_smtp_rcpt = acl_check_rcpt
+ignore_bounce_errors_after = 0s
+timeout_frozen_after = 1h
+
+__IF__ USETLS
+tls_advertise_hosts = *
+tls_certificate = __VARDIR__/spool/tmp/exim/certificate
+tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
+tls_require_ciphers = __CIPHERS__
+__ELSE__ USETLS
+tls_advertise_hosts =
+__FI__
+
+chunking_advertise_hosts =
+keep_environment =
+
+local_interfaces = 127.0.0.1
+daemon_smtp_port = 2525
+return_path_remove = true
+accept_8bitmime = true
+allow_mx_to_ip = __ALLOW_MX_TO_IP__
+message_size_limit = __GLOBAL_MAXMSGSIZE__
+__IF__ DISABLE_IPV6
+disable_ipv6 = true
+__FI__
+
+received_headers_max = __MAX_RECEIVED__
+received_header_text = "Received: \
+        ${if def:sender_rcvhost {from ${sender_rcvhost}\n\t}\
+         {${if def:sender_ident {from ${sender_ident} }}\
+         ${if def:sender_helo_name {(helo=${sender_helo_name})\n\t}}}}\
+         by $primary_hostname stage4 \
+         ${if def:received_protocol {with ${received_protocol}}} \n\t\
+         with id ${message_id} ${if def:received_for {\n\tfor <$received_for>}} ${if def:sender_address {\n\tfrom <$sender_address>}}"
+
+domainlist local_domains = @
+domainlist relay_to_domains = wildlsearch;VARDIR/spool/tmp/mailcleaner/domains.list
+domainlist forward_by_mx = wildlsearch;VARDIR/spool/tmp/mailcleaner/domains_to_mx.list
+domainlist domains_require_tls_to = VARDIR/spool/tmp/mailcleaner/domains_require_tls_to.list
+hostlist   relay_from_hosts = 127.0.0.1
+hostlist   trusted_hosts = <; __TRUSTED_HOSTS__
+addresslist full_whitelisted_senders = lsearch;VARDIR/spool/mailcleaner/full_whitelisted_senders.list
+
+perl_at_start = true
+perl_startup = do '__SRCDIR__/etc/exim/out_scripts.pl'
+
+######################################################################
+#                       ACL CONFIGURATION                            #
+#         Specifies access control lists for incoming SMTP mail      #
+######################################################################
+
+begin acl
+
+acl_check_rcpt:
+
+  accept  hosts = 127.0.0.1 :
+  deny    domains       = +local_domains
+          local_parts   = ^[.] : ^.*[@%!/|]
+  deny    domains       = !+local_domains
+          local_parts   = ^[./|] : ^.*[@%!] : ^.*/\\.\\./
+  accept  domains       = +local_domains
+          endpass
+#          verify        = recipient
+  accept  domains       = +relay_to_domains
+          endpass
+  accept  hosts         = +relay_from_hosts
+  accept  authenticated = *
+  deny    message       = relay not permitted
+
+######################################################################
+#                      ROUTERS CONFIGURATION                         #
+#               Specifies how addresses are handled                  #
+######################################################################
+begin routers
+
+full_whitelist:
+   driver     = manualroute
+   transport  = remote_smtp
+   condition  = ${if def:header_X-MailCleaner-FullWhitelist:{$h_X-MailCleaner-FullWhitelist:}{yes} }
+   senders    = +full_whitelisted_senders
+   route_data = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains.list}}
+
+filter_newsletter:
+  driver = accept
+  transport = spam_store
+  condition = ${if  match {$header_subject:}{\{MC_NEWS\}} {yes}{no} }
+  headers_remove = Subject
+  headers_add = "${perl{getNoNewsTagSubject}}"
+  headers_add = X-Auto-Response-Suppress: DR, NDR, RN, NRN, OOF, AutoReply
+  __INCLUDE__ stage4/remove_headers
+
+filter_blacklist:
+  driver = accept
+  condition = ${if >{${perl{isBlacklisted}{$local_part}{$domain}}}{0} }
+  #condition = ${if ! match {$header_X-MailCleaner-Status:}{\{${perl{getBlacklistedFlag}{$local_part}{$domain}}\}} {yes}{no} }
+  transport = spam_store
+  headers_add = X-MailCleaner-Status: Blacklisted (${perl{getBlacklistedFlag}{$local_part}{$domain}})
+  headers_remove = X-MailCleaner-Status
+  ___INCLUDE__ stage4/remove_headers
+
+__IF__ TAGMODEBYPASSWHITELISTS
+filter_checktag_mx:
+  driver = dnslookup
+  transport = remote_smtp
+  domains = !@ : +forward_by_mx
+  condition = ${if and \
+                  { \
+                     {match {$header_subject:}{^\{MC_SPAM\}}} \
+                     { >{${perl{wantTag}{$local_part}{$domain}}}{0} } \
+                  }{yes}{no} \
+                }
+
+  headers_remove = X-MailCleaner-Bounce:subject
+  headers_add = "${perl{getTaggedSubject}}"
+  headers_add = X-Auto-Response-Suppress: DR, NDR, RN, NRN, OOF, AutoReply
+#  headers_add = X-MailCleaner-ReportURL: __REPORT_URL__
+  __INCLUDE__ stage4/remove_headers
+
+filter_checktag:
+  driver = manualroute
+  transport = remote_smtp
+  domains = !@ : +relay_to_domains
+  route_data = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains.list}}
+  hosts_randomize = true
+  condition = ${if and \
+                  { \
+                     {match {$header_subject:}{^\{MC_SPAM\}}} \
+                     { >{${perl{wantTag}{$local_part}{$domain}}}{0} } \
+                  }{yes}{no} \
+                }
+  headers_remove = X-MailCleaner-Bounce:subject
+  headers_add = "${perl{getTaggedSubject}}"
+  headers_add = X-Auto-Response-Suppress: DR, NDR, RN, NRN, OOF, AutoReply
+#  headers_add = X-MailCleaner-ReportURL: __REPORT_URL__
+  __INCLUDE__ stage4/remove_headers
+__FI__
+
+filter_checkspam:
+  driver = accept
+  transport = spam_store
+  condition = ${if  match {$header_subject:}{^\{MC_SPAM\}} {yes}{no} }
+  headers_add = X-Auto-Response-Suppress: DR, NDR, RN, NRN, OOF, AutoReply
+
+filter_checkbounces:
+  driver = accept
+  transport = spam_store
+  condition = ${if and \
+                   { \
+                     { eq {$sender_address}{} } \
+                     { >{${perl{quarantineBounce}{$local_part}{$domain}}}{0} } \
+                   }{yes}{no} \
+               }
+  headers_add = X-MailCleaner-Bounce: bounce message
+  __INCLUDE__ stage4/remove_headers
+
+__IF__ USEARCHIVER
+archiver_route:
+  debug_print = "R: archiver_route for $domain"
+  driver = manualroute
+  condition = ${if eq{${local_part}@${domain}}{$original_local_part@$original_domain}}
+  domains = +relay_to_domains
+  local_parts = ${if exists{ARCHIVERDIR/${domain_data}} {nwildlsearch;ARCHIVERDIR/${domain_data}} {} }
+  transport = archiver_smtp_transport
+  route_list = * __ARCHIVER_HOST__
+  __INCLUDE__ stage4/remove_headers
+self = send
+  unseen
+  no_verify
+__FI__
+
+copyto_route:
+  debug_print = "R: copyto_route for ${local_part}@${domain}"
+  driver = redirect
+  check_ancestor
+  qualify_preserve_domain
+  headers_add = X-MailCleaner-CopyTo: this is a message copy (original recipient: ${original_local_part}@${original_domain})
+  domains = +relay_to_domains
+  data = ${if \
+            exists{COPYTODIR/${domain_data}} \
+             {${lookup{$local_part}nwildlsearch{COPYTODIR/${domain_data}}} } \
+             {}\
+          }
+  condition = ${if and { \
+                  { exists{COPYTODIR/${domain_data}} } \
+                  { !eq{${local_part}@${domain}}{${lookup{$local_part}nwildlsearch{COPYTODIR/${domain_data}}}} } } \
+                }}
+  unseen
+  repeat_use = false
+  no_verify
+  __INCLUDE__ stage4/remove_headers
+
+filter_forward_mx:
+  driver = dnslookup
+  transport = remote_smtp
+  domains = !@ : +forward_by_mx
+  headers_remove = X-MailCleaner-Bounce
+  headers_add = X-MailCleaner-ReportURL: __REPORT_URL__
+  __INCLUDE__ stage4/remove_headers
+
+filter_forward:
+  driver = manualroute
+  transport = remote_smtp
+  domains = !@ : +relay_to_domains
+  route_data = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains.list}}
+  hosts_randomize = true
+  headers_remove = X-MailCleaner-Bounce
+  headers_add = X-MailCleaner-ReportURL: __REPORT_URL__
+  __INCLUDE__ stage4/remove_headers
+
+dnslookup_gateway:
+  driver = manualroute
+  domains = ! +local_domains : ! +relay_to_domains
+  condition = ${if exists{VARDIR/spool/mailcleaner/smtp_proxy.conf}{yes}{no}}
+  transport = remote_smtp
+  route_list = wildlsearch;;VARDIR/spool/mailcleaner/smtp_proxy.conf $value
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
+  __INCLUDE__ stage4/remove_headers
+
+dnslookup:
+  driver = dnslookup
+  domains = ! +local_domains : ! +relay_to_domains
+  transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
+  __INCLUDE__ stage4/remove_headers
+
+####################
+## local deliveries
+system_aliases:
+  driver = redirect
+  allow_fail
+  allow_defer
+  data = ${lookup{$local_part}lsearch{/etc/aliases}}
+  file_transport = address_file
+  pipe_transport = address_pipe
+  __INCLUDE__ stage4/remove_headers
+
+userforward:
+  driver = redirect
+  check_local_user
+  file = $home/.forward
+  no_verify
+  no_expn
+  check_ancestor
+  file_transport = address_file
+  pipe_transport = address_pipe
+  reply_transport = address_reply
+  __INCLUDE__ stage4/remove_headers
+
+localuser:
+  driver = accept
+  check_local_user
+  transport = local_delivery
+  cannot_route_message = Unknown user
+  __INCLUDE__ stage4/remove_headers
+
+######################################################################
+#                      TRANSPORTS CONFIGURATION                      #
+######################################################################
+begin transports
+
+stockme:
+  driver = appendfile
+  create_directory = yes
+  user = mailcleaner
+  group = mailcleaner
+
+spam_pipe:
+  driver = pipe
+  user = mailcleaner
+  group = mailcleaner
+  log_output = true
+  environment = "PERLLIB=__SRCDIR__/lib"
+  command = "__OUTSCRIPT__ $message_id $local_part $domain $sender_address"
+
+spam_store:
+  driver = appendfile
+  user = mailcleaner
+  group = mailcleaner
+  mode = 640
+  mailstore_format
+  create_directory = true
+  directory = VARDIR/spool/exim_stage4/spamstore
+
+spam_transport:
+  driver = appendfile
+  user = mailcleaner
+  group = mailcleaner
+  mode = 640
+
+remote_smtp:
+  driver = smtp
+  helo_data = __HELO_NAME__
+  max_rcpt = __MAX_RCPT__
+  multi_domain = false
+  final_timeout = 120s
+  data_timeout = 120s
+  connect_timeout = 30s
+__IF__ USETLS
+  hosts_require_tls = <; ${if match_domain{$domain}{+domains_require_tls_to} {*}{__HOSTS_REQUIRE_TLS__} }
+__FI__
+  hosts_try_chunking =
+
+####################
+## local deliveries
+local_delivery:
+  driver = appendfile
+  file = /var/mail/$local_part
+  delivery_date_add
+  envelope_to_add
+  return_path_add
+
+address_pipe:
+  driver = pipe
+  return_output
+
+address_file:
+  driver = appendfile
+  delivery_date_add
+  envelope_to_add
+  return_path_add
+
+address_reply:
+  driver = autoreply
+
+archiver_smtp_transport:
+  debug_print = "T: archiving mail for $local_part@$domain"
+  driver = smtp
+  helo_data = __HELO_NAME__
+  port = __ARCHIVER_PORT__
+  allow_localhost
+__IF__ USETLS
+  hosts_require_tls = __HOSTS_REQUIRE_TLS__
+__FI__
+  hosts_try_chunking =
+
+######################################################################
+#                      RETRY CONFIGURATION                           #
+######################################################################
+
+begin retry
+
+*                      tls_required
+*                      *           __RETRY_RULE__
+
+######################################################################
+#                      REWRITE CONFIGURATION                         #
+######################################################################
+begin rewrite
+
+######################################################################
+#                   AUTHENTICATION CONFIGURATION                     #
+######################################################################
+begin authenticators
+

--- a/etc/exim/stage1/ldap_callout_template_4.94
+++ b/etc/exim/stage1/ldap_callout_template_4.94
@@ -1,0 +1,31 @@
+LDAP_AD_MAIL_RCPT = \
+  user=${quote:${lookup{user}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}} \
+  pass=${quote:${lookup{pass}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}} \
+  nettime=10 \
+  ${if >{${strlen:${lookup{usessl}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}}}{0}{ldaps://} {ldap://}}\
+  ${lookup{server}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}/${lookup{basedn}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}} \
+  ?mail?sub?\
+${if >{${strlen:${lookup{group}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}}}{0}\
+ {(&\
+  (memberOf=${lookup{group}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}})\
+ }\
+}\
+  (|\
+    (&\
+      (|\
+        (objectClass=user)\
+        (objectClass=publicFolder)\
+        (objectClass=group)\
+      )\
+      (proxyAddresses=SMTP:${quote_ldap:${local_part}}@${quote_ldap:${domain_data}})\
+    )\
+    (mail=${quote_ldap:${local_part}}@${quote_ldap:${domain_data}})\
+    (otherMailbox=smtp:${quote_ldap:${local_part}}@${quote_ldap:${domain_data}})\
+    (proxyAddresses=SMTP:${quote_ldap:${local_part}}@${quote_ldap:${domain_data}})\
+    (uid=${quote_ldap:${local_part}})\
+    (cn=${quote_ldap:${local_part}}@${quote_ldap:${domain_data}})\
+  )\
+${if >{${strlen:${lookup{group}lsearch{VARDIR/spool/tmp/mailcleaner/ldap_callouts/${domain_data}}}}}{0}\
+ {)}\
+}
+


### PR DESCRIPTION
Allow for substitution of version-specific template if it exists.

Add templates for fix filepath taintedness errors in versions => 4.93.

Add absolute path to dumper otherwise they are only dumped if PWD is already SRCIR