### PR TITLE
Correct WL address and output message

### DIFF
--- a/www/user/htdocs/newswhitelist.php
+++ b/www/user/htdocs/newswhitelist.php
@@ -131,6 +131,9 @@ if (!isset($bad_arg)) {
 
         // Get both sender and from addresses
         $sender = extractSender(get_sender_address($spam_mail));
+        if (!isset($sender) || $sender == '') {
+            $sender = get_sender_address($spam_mail);
+        }
         if (isset($_GET['t']) && $_GET['t'] != '') {
             $sender_body = $_GET['t'];
         } else {
@@ -171,8 +174,8 @@ $replace = array();
 
 // Setting the page text
 if ($is_sender_added_to_wl == 'OK' && $is_sender_added_to_wl == 'OK') {
-    $replace['__HEAD__'] = $lang_->print_txt('NEWSWHITEHEAD');
-    $replace['__MESSAGE__'] = $lang_->print_txt('NEWSWHITEBODY');
+    $replace['__HEAD__'] = $lang_->print_txt('NEWSWHITELISTHEAD');
+    $replace['__MESSAGE__'] = $lang_->print_txt('NEWSWHITELISTBODY');
 } elseif ($is_sender_added_to_news == 'OK') {
     $replace['__HEAD__'] = $lang_->print_txt('NEWSNOTWHITEHEAD');
     $replace['__MESSAGE__'] = $lang_->print_txt('NEWSNOTWHITEBODY') . ' ' . $is_sender_added_to_wl;


### PR DESCRIPTION
Whitelist would only be added if the envelope address could be simplified. Ensure that target address is set to the original envelope sender if it cannot be simplified.

Translation string from NEWSWHITELIST{BODY,HEAD} was missing 'LIST' resulting in no success message.