### PR TITLE
Add checkmark to Content Quarantine release button

### DIFF
--- a/install/dbs/t_st_maillog.sql
+++ b/install/dbs/t_st_maillog.sql
@@ -38,6 +38,7 @@ CREATE TABLE maillog (
   time time default NULL,
   headers text,
   quarantined tinyint(1) default '0',
+  content_forced enum('1','0') NOT NULL DEFAULT '0',
   KEY maillog_datetime_idx (date,time),
   KEY maillog_id_idx (id(20)),
   KEY maillog_clientip_idx (clientip(20)),

--- a/www/classes/user/Content.php
+++ b/www/classes/user/Content.php
@@ -32,7 +32,8 @@ class Content {
        'size' => 0,
        'spamreport' => '',
        'headers' => '',
-       'slave' => 0
+       'slave' => 0,
+       'content_forced' => 0
   );
  
 
@@ -126,7 +127,7 @@ public function load($id) {
     $clean_id = $db->sanitize($id);
     
     // build the query
-    $query = "SELECT timestamp, to_domain, id, from_address, to_address, subject, isspam, virusinfected, nameinfected, otherinfected, report, date, time, size, sascore, spamreport, headers FROM maillog WHERE";
+    $query = "SELECT timestamp, to_domain, id, from_address, to_address, subject, isspam, virusinfected, nameinfected, otherinfected, report, date, time, size, sascore, spamreport, headers, content_forced FROM maillog WHERE";
     $query .= " quarantined=1 AND ";
     $query .= " id='".$clean_id."'";
     

--- a/www/classes/user/ContentQuarantine.php
+++ b/www/classes/user/ContentQuarantine.php
@@ -169,7 +169,7 @@ public function load() {
    }
    
    // get the content themselves
-   $query = "SELECT timestamp, id, from_address, to_address, subject, isspam, virusinfected, nameinfected, otherinfected, report, date, time FROM maillog WHERE ";
+   $query = "SELECT timestamp, id, from_address, to_address, subject, isspam, virusinfected, nameinfected, otherinfected, report, date, time, content_forced FROM maillog WHERE ";
    $query .= $where;
    
    // set the sorting order wanted

--- a/www/guis/admin/application/models/QuarantinedContent.php
+++ b/www/guis/admin/application/models/QuarantinedContent.php
@@ -23,7 +23,8 @@ class Default_Model_QuarantinedContent
 	  'otherinfected' => 0,
 	  'nameinfected' => 0,
 	  'report' => '',
-	  'size' => 0
+	  'size' => 0,
+          'content_forced' => 0
 	);
 
 	protected $_mapper;

--- a/www/guis/admin/application/models/QuarantinedContentMapper.php
+++ b/www/guis/admin/application/models/QuarantinedContentMapper.php
@@ -68,7 +68,7 @@ class Default_Model_QuarantinedContentMapper
         foreach ($sortarray as $se => $sa) {
         	$e = $entriesflat[$se];
         	$entry = new Default_Model_QuarantinedContent();
-        	foreach (array('store_id', 'id', 'size', 'from_address', 'to_address', 'to_domain', 'subject', 'virusinfected', 'nameinfected', 'otherinfected', 'report', 'date', 'time') as $p) {
+		foreach (array('store_id', 'id', 'size', 'from_address', 'to_address', 'to_domain', 'subject', 'virusinfected', 'nameinfected', 'otherinfected', 'report', 'date', 'time', 'content_forced') as $p) {
                 $entry->setParam($p, $e[$p]);
         	}
         	$entries[] = $entry;

--- a/www/guis/admin/public/templates/default/scripts/ajax/managecontentquarantine/search.phtml
+++ b/www/guis/admin/public/templates/default/scripts/ajax/managecontentquarantine/search.phtml
@@ -54,9 +54,9 @@
    </tr>
    
 <?php $i=1; foreach ($this->elements as $element) {?>
-<tr class="quarantine_content" onmouseover="highlightActionIcon('<?php echo $i?>', 0, '', '<?php echo $this->images_path?>'); return true;" onmouseout="highlightActionIcon('<?php echo $i?>', 0, '_off', '<?php echo $this->images_path?>'); return true;">
+<tr class="quarantine_content<?php if ($element->getParam('content_forced')) { echo ' msgforced';}?>" onmouseover="highlightActionIcon('<?php echo $i?>', <?php echo $element->getParam('content_forced')?>, '', '<?php echo $this->images_path?>'); return true;" onmouseout="highlightActionIcon('<?php echo $i?>', <?php echo $element->getParam('content_forced')?>, '_off', '<?php echo $this->images_path?>'); return true;">
   <td class="c_caction">
-     <a href="javascript:cforce('<?php echo $element->getFullId()?>','<?php echo $element->getStoreId()?>');" onmouseover="showHideToolTip(event, true, 'fm', 'L'); return true;" onmouseout="showHideToolTip(event, false, '', 'L'); return true;"><img src="<?php echo $this->images_path?>/release_off.png" id="r<?php echo $i;?>" alt="release" /></a>
+     <a href="javascript:cforce('<?php echo $element->getFullId()?>','<?php echo $element->getStoreId()?>');" onmouseover="showHideToolTip(event, true, 'fm', 'L'); return true;" onmouseout="showHideToolTip(event, false, '', 'L'); return true;"><img src="<?php echo $this->images_path?>/<?php if ($element->getParam('content_forced')) { echo "released_off.png"; } else { echo "release_off.png"; }?>" id="r<?php echo $i;?>" alt="release" /></a>
      <a href="javascript:cinfos('<?php echo $element->getFullId()?>','<?php echo $element->getStoreId()?>');" onmouseover="showHideToolTip(event, true, 'vi', 'L'); return true;" onmouseout="showHideToolTip(event, false, '', 'L'); return true;"><img src="<?php echo $this->images_path?>/info_off.png" id="v<?php echo $i;?>" class="middleactionincon" alt="info" /></a>
   </td>
   <td onclick="javascript:cinfos('<?php echo $element->getFullId()?>','<?php echo $element->getStoreId()?>');;"><?php echo $element->getParam('date')?>&nbsp;&nbsp;&nbsp;<?php echo $element->getParam('time')?></td>

--- a/www/soap/application/MCSoap/Content.php
+++ b/www/soap/application/MCSoap/Content.php
@@ -10,7 +10,7 @@ class MCSoap_Content
 {
 
 	static public $_fieldstosend = array(
-	   'id', 'size', 'from_address', 'to_address', 'to_domain', 'subject', 'virusinfected', 'nameinfected', 'otherinfected', 'report', 'date', 'time'
+	   'id', 'size', 'from_address', 'to_address', 'to_domain', 'subject', 'virusinfected', 'nameinfected', 'otherinfected', 'report', 'date', 'time', 'content_forced'
 	);
   /**
    * This function will search for quarantined content


### PR DESCRIPTION
Replicates the functionality that already exists for previously released Spam Quarantine items.

Requires accompanying Updater4MC change or:

check_db.pl -s --dbs=mc_stats --update

to add necessary column to maillog table