### PR TITLE
Move Pyenv setup to tracked file, update path

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,5 @@
+export PYENV_ROOT="/var/mailcleaner/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+if command -v pyenv 1>/dev/null 2>&1; then
+  eval "$(pyenv init --path)"
+fi

--- a/etc/init.d/fail2ban
+++ b/etc/init.d/fail2ban
@@ -109,7 +109,7 @@ do_start()
 	export PYENV_ROOT="/var/mailcleaner/.pyenv"
 	export PATH="$PYENV_ROOT/bin:$PATH"
 	if command -v pyenv 1>/dev/null 2>&1; then
-	  eval "$(pyenv init -)"
+	  eval "$(pyenv init --path)"
 	fi
 	dump_fail2ban_config.py
 

--- a/etc/init.d/firewall
+++ b/etc/init.d/firewall
@@ -32,7 +32,7 @@ case "$1" in
     export PYENV_ROOT="/var/mailcleaner/.pyenv"
     export PATH="$PYENV_ROOT/bin:$PATH"
     if command -v pyenv 1>/dev/null 2>&1; then
-      eval "$(pyenv init -)"
+      eval "$(pyenv init --path)"
     fi
     fail2ban.py internal reload-fw firewall
     ;;

--- a/install/install_pyenv_3-7-7.sh
+++ b/install/install_pyenv_3-7-7.sh
@@ -50,11 +50,11 @@ then
   git clone https://github.com/pyenv/pyenv.git .pyenv
   echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bash_profile
   echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bash_profile
-  echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> .bash_profile
+  echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\nfi' >> .bash_profile
   export PYENV_ROOT="$HOME/.pyenv"
   export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init -)"
-  LD_LIBRARY_PATH="${HOME}/lib/openssl/lib" LDFLAGS="-L${HOME}/lib/openssl/lib -Wl,-rpath,${HOME}/lib/openssl/lib" CFLAGS="-I$HOME/lib/openssl/include" SSH="$HOME/lib/openssl" pyenv install 3.7.7
+  eval "$(pyenv init --path)"
+  LD_LIBRARY_PATH="${HOME}/lib/openssl/lib" LDFLAGS="-L${HOME}/lib/openssl/lib -Wl,-rpath,${HOME}/lib/openssl/lib" CFLAGS="-I$HOME/lib/openssl/include" SSH="$HOME/lib/openssl" pyenv install 3.7.7 -s
   pyenv local 3.7.7
 
   pip install mailcleaner-library --trusted-host repository.mailcleaner.net --index https://repository.mailcleaner.net/python/ --extra-index https://pypi.org/simple/


### PR DESCRIPTION
In conjuction with Update 65.

These remove the declaration of the Python environment from /root/ and instead creates a tracked .bashrc which gets sourced from there.

Update deprecated pyenv init command in other scripts.