### PR TITLE
Fix failure to bypass for recipients with no filtering

### DIFF
--- a/etc/exim/exim_stage1.conf_template_4.94
+++ b/etc/exim/exim_stage1.conf_template_4.94
@@ -124,10 +124,10 @@ __FI__
          id ${message_id} ${if def:received_for {\n\tfor <$received_for>}} ${if def:sender_address {\n\tfrom <$sender_address>}}"
 
 domainlist local_domains =
-domainlist relay_to_domains = wildlsearch;VARDIR/spool/tmp/mailcleaner/domains.list
+domainlist relay_to_domains = wildlsearch,ret=key;VARDIR/spool/tmp/mailcleaner/domains.list
 domainlist domains_to_callout = VARDIR/spool/tmp/mailcleaner/domains_to_callout.list
 domainlist domains_to_extcallout = VARDIR/spool/tmp/mailcleaner/domains_to_extcallout.list
-domainlist domains_to_altcallout = lsearch;VARDIR/spool/tmp/mailcleaner/domains_to_altcallout.list
+domainlist domains_to_altcallout = lsearch,ret=key;VARDIR/spool/tmp/mailcleaner/domains_to_altcallout.list
 domainlist domains_to_addlistcallout = VARDIR/spool/tmp/mailcleaner/domains_to_addlistcallout.list
 domainlist domains_to_adcheck = VARDIR/spool/tmp/mailcleaner/domains_to_adcheck.list
 domainlist domains_to_greylist = VARDIR/spool/tmp/mailcleaner/domains_to_greylist.list


### PR DESCRIPTION
As of Exim 4.94 we need to use the sanitized $domain_data instead of $domain. However, unlike $domain, $domain_data will retain resulting values from a lookup. This means that for a lookup like:

  wildlsearch;VARDIR/spool/tmp/mailcleaner/domains.list

which contains:

  domain.com:  destination.server:25 byname randomize

$domain_data would contain the value instead of the key (domain name), resulting in the wrong file being looked up for later searching using $domain_data.

To resolve this we need to specify that the lookup should return the key instead:

  wildlsearch;ret=key;VARDIR/spool/tmp/mailcleaner/domains.list