### PR TITLE
Prevent double quarantine for newsl and bl

### DIFF
--- a/etc/exim/exim_stage4.conf_template_4.94
+++ b/etc/exim/exim_stage4.conf_template_4.94
@@ -124,7 +124,12 @@ filter_newsletter:
 
 filter_blacklist:
   driver = accept
-  condition = ${if >{${perl{isBlacklisted}{$local_part}{$domain}}}{0} }
+  condition = ${if and \
+                  { \
+                    { >{${perl{isBlacklisted}{$local_part}{$domain}}}{0} } \
+                    { !match{$header_X-MailCleaner-Forced:}{message forced} } \
+                  }{yes}{no} \
+                }
   #condition = ${if ! match {$header_X-MailCleaner-Status:}{\{${perl{getBlacklistedFlag}{$local_part}{$domain}}\}} {yes}{no} }
   transport = spam_store
   headers_add = X-MailCleaner-Status: Blacklisted (${perl{getBlacklistedFlag}{$local_part}{$domain}})


### PR DESCRIPTION
Stage 4 has a redundant check for blacklisted senders which could have bypassed the filtering stage. To ignore a blacklist result, it must already have a Blacklisted header.

The problem is that messages that are quarantined for other reasons, or a sender that was blacklisted after the message was quarantined will not have this header either. This results in Stage 4 adding the header to a released message and re-quarantining it. This fix simply checks if the message was forced and will also ignore blacklists during Stage 4 for that reason.