### PR TITLE
Create priority route for forced messages

### DIFF
--- a/etc/exim/exim_stage4.conf_template_4.94
+++ b/etc/exim/exim_stage4.conf_template_4.94
@@ -106,6 +106,12 @@ acl_check_rcpt:
 ######################################################################
 begin routers
 
+forced:
+  driver      = manualroute
+  transport   = remote_smtp
+  condition   = ${if match{$header_X-MailCleaner-Forced:}{message forced}}
+  route_data  = ${lookup{$domain}wildlsearch{VARDIR/spool/tmp/mailcleaner/domains.list}}
+
 full_whitelist:
    driver     = manualroute
    transport  = remote_smtp


### PR DESCRIPTION
New first route to always deliver messages with a forced header.