### PR TITLE
Capture real From header when Real Name is an email

### DIFF
--- a/www/soap/htdocs/parts/message.php
+++ b/www/soap/htdocs/parts/message.php
@@ -167,6 +167,8 @@ function getHeaders($id, $dest) {
   $line = 0;
   $soap_ret = new SoapText();
   while( !preg_match('/^$/',$file[$line])) {
+    $file[$line] = preg_replace('/</','&lt;',$file[$line]);
+    $file[$line] = preg_replace('/>/','&gt;',$file[$line]);
     array_push($ret, utf8_encode($file[$line]));
     $line++;
   }

--- a/www/user/htdocs/fm.php
+++ b/www/user/htdocs/fm.php
@@ -73,8 +73,8 @@ $spam_mail->loadDatas($_GET['id'],$_GET['a']);
 if (isset($_GET['n']) && $_GET['n'] == 1) {
   $spam_mail->loadHeadersAndBody();
   $from = $spam_mail->getHeadersArray()['From'];
-  preg_match('/[<]?([-0-9a-zA-Z.+_\']+@[-0-9a-zA-Z.+_\']+\.[a-zA-Z-0-9]+)[>]?/', trim($from), $original_sender);
-  $original_sender = $original_sender[1];
+  preg_match_all('/[<]?([-0-9a-zA-Z.+_\']+@[-0-9a-zA-Z.+_\']+\.[a-zA-Z-0-9]+)[>]?/', trim($from), $original_sender);
+  $original_sender = $original_sender[0][sizeof($original_sender[0])-1];
 } else {
   $original_sender = $spam_mail->getData("sender");
 }


### PR DESCRIPTION
In the case of:

"fake@spam.com" <real@domain.com>

the incorrect address was returned. Required escaping of <> in SOAP response and capturing all preg matches in header.