### PR TITLE
Allow multiple terms for tracing and search_log.pl

### DIFF
--- a/bin/search_log.pl
+++ b/bin/search_log.pl
@@ -13,7 +13,7 @@ my $stop = shift;
 my $what = shift;
 my $batch = 0;
 my $includerefused = 1;
-my $filter = ' ';
+my @filter = ();
 my $fakeids = 1;
 my $batchwithlog = 0;
 my $batchid = 0;
@@ -26,13 +26,13 @@ if (! $start  || ! $stop || ! $what ) {
   print_usage();
 }
 while (my $opt = shift) {
-  if ($opt =~ /-\S*b/) {
+  if ($opt =~ /^-\S*b/) {
     $batch = 1;
   }
-  if ($opt =~ /-\S*R/) {
+  if ($opt =~ /^-\S*R/) {
     $includerefused = 0;
   }
-  if ($opt =~ /-\S*B/) {
+  if ($opt =~ /^-\S*B/) {
     $batchid = shift;
     $batch = 1;
     if (!$batchid) {
@@ -43,7 +43,7 @@ while (my $opt = shift) {
     }
   }
   if ($opt !~ /^-/) {
-    $filter = $opt;
+    push(@filter, $opt);
   }  
 }
 
@@ -103,13 +103,15 @@ loopThroughLogs('exim_stage1/mainlog', 'exim', $what, \%stage1_ids);
 foreach my $msg (@nf_messages) {
 	my %msg_o = %{$msg};
 	my $filtermatch = 0;
-	foreach my $line (split '\n', $stage1_ids{$msg_o{'id'}}) {
-	   if ($line =~ m/$filter/i) {
-	   	  $filtermatch = 1;
-	   	  last;
-	   }
+        foreach my $f (@filter) {
+	    foreach my $line (split '\n', $stage1_ids{$msg_o{'id'}}) {
+	        if ($line =~ m/$f/i) {
+	   	    $filtermatch++;
+	   	    last;
+	        }
+            }
 	}
-	if ($filtermatch) {
+	if ($filtermatch == scalar(@filter)) {
 		my $refused = 0;
 		if ( ! $includerefused ) {
 			# List of regexp matching the refused messages

--- a/www/guis/admin/application/forms/Tracing.php
+++ b/www/guis/admin/application/forms/Tracing.php
@@ -46,7 +46,8 @@ class Default_Form_Tracing extends ZendX_JQuery_Form
 	    $this->addElement($domainField);
 	    
 	    $sender = new  Zend_Form_Element_Text('sender', array(
-	        'label' => $t->_('Filter by external address')." : ",
+	        'label' => $t->_('Filter by log detail')." : ",
+                'title' => $t->_('Enter value for another attribute of the message such as the external address, hostname, Message Id or Queue Id. Search multiple criteria by separating with a space.'),
 	        'size' => 40,
 		    'required' => false));
 	    $sender->setValue($this->_params['sender']);

--- a/www/soap/application/MCSoap/Logs.php
+++ b/www/soap/application/MCSoap/Logs.php
@@ -34,7 +34,10 @@ class MCSoap_Logs
 		}
 		$cmd = $mcconfig->getOption('SRCDIR')."/bin/search_log.pl ".$params['datefrom']." ".$params['dateto']." ".$params['regexp'];
         if (isset($params['filter']) && $params['filter'] != '' && $params['filter'] != "''") {
-            $cmd .= " ".$params['filter'];
+            $params['filter'] = preg_replace("/^'(.*)'$/", "$1", $params['filter']);
+            $params['filter'] = preg_replace("/'/", "\\'", $params['filter']);
+            $params['filter'] = preg_replace("/\s+/", "' '", $params['filter']);
+            $cmd .= " '" . $params['filter'] . "'";
         }
 
                 if (isset($params['hiderejected']) && $params['hiderejected']) {


### PR DESCRIPTION
* Add ^ anchor to other options since a QueueId could make the script think that it had received incomplete options.
* Change the filter scalar to an array. Instead of a boolean match, the number of matches must meet the number of filter terms.
* Change the label in Tracing and add a tooltip
* Add proper quoting and escapes to allow the Tracing filter to perform a proper, safe log search