### PR TITLE
DKIM sign messages that were full-whitelisted

### DIFF
--- a/etc/exim/exim_stage1.conf_template_4.94
+++ b/etc/exim/exim_stage1.conf_template_4.94
@@ -1158,6 +1158,12 @@ bypass_full_whitelist:
   hosts = localhost
   interface = 127.0.0.1
   port = 2525
+  dkim_domain = ${extract {1}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}
+  dkim_selector = ${extract {2}{;} {${lookup {${domain:$return_path}} lsearch {DKIMFILE}}}}
+  dkim_private_key = ${if exists {VARDIR/spool/tmp/mailcleaner/dkim/${dkim_domain}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/${dkim_domain}.pkey} \
+                          {VARDIR/spool/tmp/mailcleaner/dkim/default.pkey} \
+                      }
 
 bypass_smtp:
   driver = smtp


### PR DESCRIPTION
If the outbound sender had been full-whitelisted it bypasses the routers with DKIM signing. This replicates the signing in the bypass_full_whitelist router.