### PR TITLE
Allow @ in admin accesses search

### DIFF
--- a/www/guis/admin/application/models/AdministratorMapper.php
+++ b/www/guis/admin/application/models/AdministratorMapper.php
@@ -97,7 +97,7 @@ class Default_Model_AdministratorMapper
     	
     	if (isset($params['username'])) {
     		$str = preg_replace('/\*/', '%', $params['username']);
-    		$str = preg_replace('/[^0-9a-zA-Z._\-]/', '', $str);
+    		$str = preg_replace('/[^0-9a-zA-Z._\-@]/', '', $str);
     		$query->where('username LIKE ?', $str."%");
     	}
         $resultSet = $this->getDbTable()->fetchAll($query);


### PR DESCRIPTION
Some users set up admins using a full email address. Without this patch, the @ is not searchable.