### PR TITLE
Move full whitelisted hostlist to dedicated file

### DIFF
--- a/bin/dump_exim_config.pl
+++ b/bin/dump_exim_config.pl
@@ -914,6 +914,19 @@ sub get_exim_config{
     $config{'forbid_clear_auth'} = $row{'forbid_clear_auth'};
     $config{'dkim_default_pkey'} = $row{'dkim_default_pkey'};
     $config{'allow_relay_for_unknown_domains'} = $row{'allow_relay_for_unknown_domains'};
+    my $vardir = $conf->getOption('VARDIR');
+    my $fh;
+    $config{'__FULL_WHITELIST_HOSTS__'} = '';
+    if (-e $vardir.'/spool/mailcleaner/full_whitelisted_hosts.list') {
+        open($fh, '<', $vardir.'/spool/mailcleaner/full_whitelisted_hosts.list');
+        while (<$fh>) {
+	    $config{'__FULL_WHITELIST_HOSTS__'} .= $_ . ' ';
+        }
+        chomp($config{'__FULL_WHITELIST_HOSTS__'});
+    }
+    if ($config{'__FULL_WHITELIST_HOSTS__'} != '') {
+          $config{'__FULL_WHITELIST_HOSTS__'} = join(' ; ',expand_host_string($config{'__FULL_WHITELIST_HOSTS__'},('dumper'=>'exim/full_whitelist_hosts')));
+    }
     return %config;
 }
 

--- a/etc/exim/exim_stage1.conf_template_4.94
+++ b/etc/exim/exim_stage1.conf_template_4.94
@@ -144,6 +144,7 @@ hostlist   relay_from_hosts = <; 127.0.0.1 ; __RELAY_FROM_HOSTS__
 hostlist   trusted_hosts = <; +relay_from_hosts ; __TRUSTED_HOSTS__
 hostlist   html_ctrl_hosts = <; __HTML_CTRL_WL_HOSTS__
 hostlist   no_ratelimit_hosts = <; __NO_RATELIMIT_HOSTS__
+hostlist   full_whitelisted_hosts = <; __FULL_WHITELIST_HOSTS__
 domainlist relayrefuseddomains = VARDIR/spool/tmp/exim/blacklists/relaytodomains
 RELAYDEST = VARDIR/spool/tmp/mailcleaner/relay_accepteddest.list
 
@@ -270,7 +271,10 @@ acl_check_rcpt:
 
 # FULLWHITELIST
   accept
-          hosts         = +trusted_hosts
+          hosts         = ${if exists {VARDIR/spool/mailcleaner/full_whitelisted_hosts.list}\
+                               {+full_whitelisted_hosts}\
+                               {+trusted_hosts}\
+                          }
           senders       = +full_whitelisted_senders
 
   accept  hosts = <; ;
@@ -807,7 +811,10 @@ __FI__
 acl_check_mime:
 
 # FULLWHITELIST
-  accept  hosts         = +trusted_hosts
+  accept  hosts         = ${if exists {VARDIR/spool/mailcleaner/full_whitelisted_hosts.list}\
+                               {+full_whitelisted_hosts}\
+                               {+trusted_hosts}\
+                          }
           senders       = +full_whitelisted_senders
 
 __IF__ LOG_ATTACHMENTS
@@ -933,7 +940,10 @@ acl_check_data:
 # FULLWHITELIST
   accept  remove_header = X-MailCleaner-FullWhitelist
           remove_header = X-Newsl
-          hosts         = +trusted_hosts
+          hosts         = ${if exists {VARDIR/spool/mailcleaner/full_whitelisted_hosts.list}\
+                               {+full_whitelisted_hosts}\
+                               {+trusted_hosts}\
+                          }
           senders       = +full_whitelisted_senders
 
 __IF__ OUTGOINGVIRUSSCAN
@@ -1008,7 +1018,21 @@ begin routers
 full_whitelist:
   driver     = accept
   transport  = bypass_full_whitelist
-  condition  = ${if match_ip{$sender_host_address}{+trusted_hosts} {yes}}
+  condition  = ${\
+                   if exists {VARDIR/spool/mailcleaner/full_whitelisted_hosts.list} {\
+                       ${\
+                           if match_ip{$sender_host_address}{+full_whitelisted_hosts}\
+                               {yes}\
+                               {no}\
+                       }\
+                   } {\
+                       ${\
+                           if match_ip{$sender_host_address}{+trusted_hosts}\
+                               {yes}\
+                               {no}\
+                       }\
+                   }\
+               }
   senders    = +full_whitelisted_senders
   headers_add = X-MailCleaner-FullWhitelist: fully whitelisted
 


### PR DESCRIPTION
The file is full_whitelisted_hosts.list, in the same directory as full_whitelisted_senders.list

If this file does not exist, continue to use the trusted_ips list to support legacy setups.

This file is dumped with the dns expansion module, so it supports the exact same formats as trusted_ips.

This is preferable to continued use of trusted_ips because the latter requires that all other (not fully whitelisted) senders from those IPs must skip spam checking even if you don't want them to.