### PR TITLE
Bug Fix: trusted host rate limits

### DIFF
--- a/bin/dump_exim_config.pl
+++ b/bin/dump_exim_config.pl
@@ -732,7 +732,7 @@ sub get_exim_config{
     return unless %row;
 
 	$config{'__SMTP_ACCEPT_MAX_PER_HOST__'} = $row{'smtp_accept_max_per_host'};
-	$config{'__SMTP_ACCEPT_MAX_PER_TRUSTED_HOST__'} = 0;
+	$config{'__SMTP_ACCEPT_MAX_PER_TRUSTED_HOST__'} = $row{'smtp_accept_max_per_trusted_host'} || 0;
         $config{'__CIPHERS__'} = $row{'ciphers'};
 	if ($config{'__CIPHERS__'} eq '') {
                 $config{'__CIPHERS__'} = 'ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM:!SSLv2';
@@ -749,10 +749,10 @@ sub get_exim_config{
         if ($config{'__RELAY_FROM_HOSTS__'}) {
           $config{'__RELAY_FROM_HOSTS__'} = join(' ; ',expand_host_string($config{'__RELAY_FROM_HOSTS__'},('dumper'=>'exim/relay_from_hosts')));
         }
+    my $dns = GetDNS->new();
+    $config{'__NO_RATELIMIT_HOSTS__'} = $dns->getA($m_infos{'host'});
     if (defined( $row{'no_ratelimit_hosts'}) && $row{'no_ratelimit_hosts'} ne '' ) {
-          $config{'__NO_RATELIMIT_HOSTS__'} = join(' ; ',($m_infos{'host'}),expand_host_string($row{'no_ratelimit_hosts'},('dumper'=>'exim/no_ratelimit_hosts')));
-    } else {
-         $config{'__NO_RATELIMIT_HOSTS__'} = $m_infos{'host'};
+          $config{'__NO_RATELIMIT_HOSTS__'} = join(' ; ',expand_host_string($config{'__NO_RATELIMIT_HOSTS__'} . ' ' . $row{'no_ratelimit_hosts'},('dumper'=>'exim/no_ratelimit_hosts')));
     }
     if (!defined($config{'__RELAY_FROM_HOSTS__'})) {
         $config{'__RELAY_FROM_HOSTS__'} = '';
@@ -763,7 +763,7 @@ sub get_exim_config{
     	 $config{'__HOSTS_REQUIRE_TLS__'} = '';
     }
     if ($config{'__HOSTS_REQUIRE_TLS__'}) {
-          $config{'__HOSTS_REQUIRE_TLS__'} = join(' ; ',expand_host_string($config{'__SMTP_CONN_ACCESS__'},('dumper'=>'exim/hosts_require_tls')));
+          $config{'__HOSTS_REQUIRE_TLS__'} = join(' ; ',expand_host_string($config{'__HOSTS_REQUIRE_TLS__'},('dumper'=>'exim/hosts_require_tls')));
     }
 
     if (defined( $row{'hosts_require_incoming_tls'}) ) {

--- a/etc/exim/exim_stage1.conf_template_4.94
+++ b/etc/exim/exim_stage1.conf_template_4.94
@@ -68,7 +68,15 @@ __IF_USE_SYSLOG__
 __INCLUDE__ stage1/force_disable_ipv6
 
 smtp_enforce_sync = __SMTP_ENFORCE_SYNC__
-smtp_accept_max_per_host = ${if match_ip{$sender_host_address}{+trusted_hosts}{__SMTP_ACCEPT_MAX_PER_TRUSTED_HOST__}{__SMTP_ACCEPT_MAX_PER_HOST__}}
+smtp_accept_max_per_host = ${if match_ip{$sender_host_address}{+no_ratelimit_hosts}\
+                               {0}\
+                               {\
+                                   ${if match_ip{$sender_host_address}{+trusted_hosts}\
+                                       {__SMTP_ACCEPT_MAX_PER_TRUSTED_HOST__}\
+                                       {__SMTP_ACCEPT_MAX_PER_HOST__}\
+                                   }\
+                               }\
+                           }
 smtp_receive_timeout = __SMTP_RECEIVE_TIMEOUT__
 smtp_accept_max = __SMTP_ACCEPT_MAX__
 smtp_load_reserve = __SMTP_LOAD_RESERVE__

--- a/www/guis/admin/application/forms/SmtpResourcesControl.php
+++ b/www/guis/admin/application/forms/SmtpResourcesControl.php
@@ -265,6 +265,7 @@ class Default_Form_SmtpResourcesControl extends ZendX_JQuery_Form
 		$mta->setparam('max_rcpt', $request->getParam('max_rcpt'));
 		$mta->setparam('smtp_accept_max', $request->getParam('smtp_accept_max'));
 		$mta->setparam('smtp_accept_max_per_host', $request->getParam('smtp_accept_max_per_host'));
+		$mta->setparam('smtp_accept_max_per_trusted_host', $request->getParam('smtp_accept_max_per_trusted_host'));
                 $mta->setparam('smtp_accept_max_per_connection', $request->getParam('smtp_accept_max_per_connection'));
         $mta->setparam('smtp_reserve', $request->getParam('smtp_reserve'));
         $mta->setparam('smtp_load_reserve', $request->getParam('smtp_load_reserve'));


### PR DESCRIPTION
Issues resolved:

Change to "per trusted host" simultaneous connection settings were not saved.

Trusted host limit was not actually utilized (was set to 0; unlimited)

Invalid server hostname dumped to hostlist (accepts only IPs). Dumps A record or nothing.

'no_ratelimit_hosts' were not actually exempted from the simultaneous rate limit.

Unrelated correction to __HOSTS_REQUIRE_TLS__ column dump.