### PR TITLE
Bug Fix: dump master hostname cname

### DIFF
--- a/bin/dump_exim_config.pl
+++ b/bin/dump_exim_config.pl
@@ -750,7 +750,7 @@ sub get_exim_config{
           $config{'__RELAY_FROM_HOSTS__'} = join(' ; ',expand_host_string($config{'__RELAY_FROM_HOSTS__'},('dumper'=>'exim/relay_from_hosts')));
         }
     my $dns = GetDNS->new();
-    $config{'__NO_RATELIMIT_HOSTS__'} = $dns->getA($m_infos{'host'});
+    $config{'__NO_RATELIMIT_HOSTS__'} = $dns->getA($m_infos{'host'}) || '';
     if (defined( $row{'no_ratelimit_hosts'}) && $row{'no_ratelimit_hosts'} ne '' ) {
           $config{'__NO_RATELIMIT_HOSTS__'} = join(' ; ',expand_host_string($config{'__NO_RATELIMIT_HOSTS__'} . ' ' . $row{'no_ratelimit_hosts'},('dumper'=>'exim/no_ratelimit_hosts')));
     }

--- a/lib/GetDNS.pm
+++ b/lib/GetDNS.pm
@@ -178,11 +178,13 @@ sub getA
 	my $target = shift;
 	
 	my $res = $self->{'resolver'}->query($target, 'A');
-	if ($res) {
+	if (defined($res->{'answer'}->[0]->{'address'})) {
 		return ($res->answer)[0]->address;
+	} elsif (defined($res->{'answer'}->[0]->{'cname'})) {
+		return $self->getA(join('.',@{$res->{'answer'}->[0]->{'cname'}->{'label'}}));
+	} else {
+		return ();
 	}
-
-	return ();
 }
 
 sub getAAAA


### PR DESCRIPTION
If the hostname of the master is a CNAME, the Net::DNS library would throw an error when we requested the A record causing the dumper to exit early.