### PR TITLE
Add fail2ban and cron to new service management

### DIFF
--- a/etc/init.d/cron
+++ b/etc/init.d/cron
@@ -18,7 +18,7 @@
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-#   /etc/init.d/fail2ban: service management for Fail2Ban
+#   /etc/init.d/cron: service management for Cron scheduler
 
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ use warnings;
 use lib '/usr/mailcleaner/lib';
 use ManageServices;
 
-our $service = 'fail2ban';
+our $service = 'cron';
 
 my $manager = ManageServices->new( 'autoStart' => 0 ) || die "Failed to create object: $!\n";
 $manager->loadModule($service) || die "Could not load module for service: $service\n";

--- a/lib/ManageServices.pm
+++ b/lib/ManageServices.pm
@@ -81,7 +81,7 @@ our %defaultActions = (
 			if (scalar(@pids)) {
 				return 'running with pid(s) ' . join(', ', @pids);
 			} else {
-				return 0;
+				return $self->clearFlags(0);
 			}
 		},
 	},
@@ -180,11 +180,11 @@ sub getServices
 			'module'	=> 'ClamSpamD',
 			'critical'	=> 1,
 		},
-		#'cron'		=> {
-			#'name'		=> 'Scheduler',
-			#'module'	=> 'Cron',
-			#'critical'	=> 1,
-		#},
+		'cron'		=> {
+			'name'		=> 'Scheduler',
+			'module'	=> 'Cron',
+			'critical'	=> 1,
+		},
 		#'dccifd' 	=> {
 			#'name'		=> 'DCC client daemon',
 			#'module'	=> 'Apache',
@@ -205,11 +205,11 @@ sub getServices
 			#'module'	=> 'Exim',
 			#'critical'	=> 1,
 		#},
-		#'fail2ban'	=> {
-			#'name'		=> 'Fail2Ban',
-			#'module'	=> 'Fail2Ban',
-			#'critical'	=> 1,
-		#},
+		'fail2ban'	=> {
+			'name'		=> 'Fail2Ban',
+			'module'	=> 'Fail2Ban',
+			'critical'	=> 0,
+		},
 		#'greylistd'	=> {
 			#'name'		=> 'Greylist daemon',
 			#'module'	=> 'GreylistD',
@@ -390,7 +390,7 @@ sub findProcess
 			return $p->{'pid'};
 		}
 	}
-	return 0;
+	return $self->clearFlags(0);
 }
 
 sub pids
@@ -555,8 +555,7 @@ sub start
 
 	if ($self->findProcess()) {
 		$self->doLog( $self->{'service'} . ' already running.', 'daemon' );
-		$self->clearFlags(1);
-		return 1;
+		return $self->clearFlags(1);
 	} 
 
 	$self->setup();
@@ -595,7 +594,7 @@ sub start
 				return $self->clearFlags(1);
 			} else {
 				$self->doLog( 'Deamon doesn\'t exist after start. Failed', 'daemon' );
-				return 0;
+				return $self->clearFlags(0);
 			}
         	} elsif ($pid == -1) {
 			$self->doLog( 'Failed to fork', 'daemon' );
@@ -609,7 +608,7 @@ sub start
 					print STDERR "Can't set GID " . 
 						$self->{'module'}->{'gid'} . 
 						" (" . $( . " " . $) . ")\n";
-					return 0;
+					return $self->clearFlags(0);
 				}
 			}
 			$self->doLog('Set GID to ' . $self->{'module'}->{'group'} . 
@@ -621,7 +620,7 @@ sub start
 					print STDERR "Can't set UID " .
 						$self->{'module'}->{'uid'} . 
 						" (" . $< . " " . $> . ")\n";
-					return 0;
+					return $self->clearFlags(0);
 				}
 			}
 			$self->doLog('Set UID to ' . $self->{'module'}->{'user'} .
@@ -911,7 +910,7 @@ sub newChild
 
 	my $thread_count = scalar(threads->list);
 	if ($thread_count >= $self->{'module'}->{'children'}) {
-		return 0;
+		return $self->clearFlags(0);
 	}
 	$self->doLog(
 		"Launching new thread (" . ($thread_count+=1) . "/" .
@@ -953,7 +952,7 @@ sub writePidFile
 		return 1;
 	} else {
 		print STDERR "Warning: $self->{'module'}->{'pidfile'} is not writable\n";
-		return 0;
+		return $self->clearFlags(0);
 	}
 }
 

--- a/lib/ManageServices/Cron.pm
+++ b/lib/ManageServices/Cron.pm
@@ -1,0 +1,90 @@
+#!/usr/bin/perl -w
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+package ManageServices::Cron;
+
+use strict;
+use warnings;
+
+our @ISA = "ManageServices";
+
+sub init 
+{
+	my $module = shift;
+	my $class = shift;
+	my $self = $class->SUPER::createModule( config($class) );
+	bless $self, 'ManageServices::Cron';
+
+	return $self;
+}
+
+sub config
+{
+	my $class = shift;
+
+	my $config = {
+		'name' 		=> 'cron',
+		'cmndline'	=> '/usr/sbin/cron',
+		'cmd'		=> '/usr/sbin/cron',
+		'pidfile'	=> '/var/run/cron.pid',
+		'user'		=> 'root',
+		'group'		=> 'root',
+		'daemonize'	=> 'no',
+		'forks'		=> 0,
+		'syslog_facility' => 'local1',
+		'debug'		=> 0,
+		'log_sets'	=> 'all',
+		'loglevel'	=> 'info',
+		'timeout'	=> 5,
+		'actions'	=> {},
+	};
+	
+	return $config;
+}
+
+sub setup
+{
+	my $self = shift;
+	my $class = shift;
+
+	return 1;
+}
+
+sub preFork
+{
+	my $self = shift;
+	my $class = shift;
+
+	return 0;
+}
+
+sub mainLoop
+{
+	my $self = shift;
+	my $class = shift;
+	
+	my $cmd = $self->{'cmd'};
+	$self->doLog("Running $cmd", 'daemon');
+	system("$cmd");
+
+	return 1;
+}
+
+1;

--- a/lib/ManageServices/Fail2Ban.pm
+++ b/lib/ManageServices/Fail2Ban.pm
@@ -1,0 +1,128 @@
+#!/usr/bin/perl -w
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+package ManageServices::Fail2Ban;
+
+use strict;
+use warnings;
+
+our @ISA = "ManageServices";
+
+sub init 
+{
+	my $module = shift;
+	my $class = shift;
+	my $self = $class->SUPER::createModule( config($class) );
+	bless $self, 'ManageServices::Fail2Ban';
+
+	return $self;
+}
+
+sub config
+{
+	my $class = shift;
+
+	my $config = {
+		'name' 		=> 'fail2ban',
+		'cmndline'	=> 'fail2ban-server',
+		'cmd'		=> '/usr/bin/fail2ban-server',
+		'confdir'	=> $class->{'conf'}->getOption('SRCDIR').'/etc/fail2ban/',
+		'localsocket'	=> $class->{'conf'}->getOption('VARDIR').'/run/fail2ban.sock',
+		'pidfile'	=> $class->{'conf'}->getOption('VARDIR').'/run/fail2ban.pid',
+		'children'	=> 1,
+		'user'		=> 'root',
+		'group'		=> 'root',
+				
+#here
+		'daemonize'	=> 'yes',
+		'forks'		=> 0,
+		'nouserconfig'  => 'yes',
+		'syslog_facility' => '',
+		'debug'		=> 0,
+		'log_sets'	=> 'all',
+		'loglevel'	=> 'info',
+		'timeout'	=> 5,
+		'checktimer'	=> 10,
+		'actions'	=> {},
+	};
+	
+	return $config;
+}
+
+sub setup
+{
+	my $self = shift;
+	my $class = shift;
+
+	# Load Default options and other rcS variables
+	foreach my $file ( qw( /etc/default/fail2ban /etc/default/rcS ) ) {
+		if ( -r $file ) {
+			open(my $fh, '<', $file);
+			while (<$fh>) {
+				if ($_ =~ m/^([A-Z_])=['"](.*)['"]$/) {
+					$ENV{$1} = $2;
+				}
+			}
+		}
+	}
+
+	$ENV{'PYENV_ROOT'} = "/var/mailcleaner/.pyenv";
+        $ENV{'PATH'} = $ENV{'PYENV_ROOT'} . "/bin:" . $ENV{'PATH'};
+	if (system("which pyenv > /dev/null")) {
+          	system("pyenv init --path");
+	}
+
+	unless ( -d "/var/run/fail2ban" ) {
+		mkdir("/var/run/fail2ban");
+	}
+
+	return 1;
+}
+
+sub preFork
+{
+	my $self = shift;
+	my $class = shift;
+
+	return 0;
+}
+
+sub mainLoop
+{
+	my $self = shift;
+	my $class = shift;
+	
+	my $cmd = $self->{'cmd'};
+	if (defined($ENV{'FAIL2BAN_OPTS'})) {
+		$cmd .= ' ' . $ENV{'FAIL2BAN_OPTS'};
+	}
+        system("dump_fail2ban_config.py");
+
+	$cmd .= ' ' . $self->{'confdir'};
+	system($cmd);
+	return 0;
+	unless ($self->{'user'} eq 'root') {
+		chown($self->{'user'}, $self->{'group'}, ( "/var/run/fail2ban" ));
+	}
+	
+	return 1;
+}
+
+1;


### PR DESCRIPTION
Also does a better job of returning the state by having the clearFlags function run always. Was possibled for non-critical modules to return a 'critical' result previously.