### PR TITLE
add protocol as a key to iptables rules creation file

### DIFF
--- a/bin/dump_firewall.pl
+++ b/bin/dump_firewall.pl
@@ -132,7 +132,7 @@ sub get_external_rules {
      foreach my $ip (expand_host_string($ref->{'allowed_ip'},('dumper'=>'snmp/allowedip'))) {
        # IPs already validated and converted to CIDR in expand_host_string, just remove non-CIDR entries
        if ($ip =~ m#/\d+$#) {
-           $rules{"host ".$ip.", service ".$ref->{'service'}} = [ $ref->{'port'}, $ref->{'protocol'}, $ip];
+           $rules{"host ".$ip.", service ".$ref->{'service'}.", protocol ".$ref->{'protocol'}} = [ $ref->{'port'}, $ref->{'protocol'}, $ip];
        }
      }
   }


### PR DESCRIPTION
When starting the firewall, a file is created from the database table "external_access". Sometimes it is necessary to add a rule for a port on multiple protocols. As an example, port 53 (DNS) can be open for TCP *and* UDP. So the table looks like this :
`mysql> select * from external_access;

+----+--------------+--------+----------+-------------+------+
| id | service      | port   | protocol | allowed_ip  | auth |
+----+--------------+--------+----------+-------------+------+
|  1 | web          | 80:443 | TCP      | 0.0.0.0/0   | NULL |
|  4 | mail         | 25     | TCP      | 0.0.0.0/0   | NULL |
| 16 | configurator | 4242   | TCP      | 0.0.0.0/0   | NULL |
| 17 | ssh          | 22     | TCP      | 0.0.0.0/0   | NULL |
| 21 | dns          | 53     | TCP      | 0.0.0.0/0   | NULL |
| 22 | dns          | 53     | UDP      | 0.0.0.0/0   | NULL |
+----+--------------+--------+----------+-------------+------+
`
But, the script bin/dump_firewall.pl, take only "host"+"port" as a key to build a table in perl, so the second record (53 UDP) overwrite the first one (53 TCP) because "host" (= "allowed_ip") + port are the same.
Adding the protocol in the KEY part of the multi-dimentional table %rules solved this.