### PR TITLE
Skip and log entries with asterisks

### DIFF
--- a/lib/GetDNS.pm
+++ b/lib/GetDNS.pm
@@ -72,6 +72,9 @@ sub dumper {
 			if ($item eq '*') {
 				$self->{recursion} = $recursion;
 				return ( '::0/0', '0.0.0.0/0' );
+			} elsif ($item =~ m/\*/) {
+				push(@invalid,$item);
+				delete($cache{$item});
 			} elsif ($item =~ m#^\!(.*)$#) {
 				push(@exceptions, $1);
 				delete($cache{$item});


### PR DESCRIPTION
Does not apply to 'all' when entry is '^\*$'