### PR TITLE
Always allow ip6 for snmp to master

### DIFF
--- a/bin/dump_snmpd_config.pl
+++ b/bin/dump_snmpd_config.pl
@@ -100,9 +100,7 @@ sub dump_snmpd_file
 	my $ip;
 	foreach $ip ( keys %master_hosts) {
 		print TARGET "com2sec local     $ip     $snmpd_conf{'__COMMUNITY__'}\n";
-		if ($ipv6) {
-			print TARGET "com2sec6 local     $ip     $snmpd_conf{'__COMMUNITY__'}\n";
-		}
+		print TARGET "com2sec6 local     $ip     $snmpd_conf{'__COMMUNITY__'}\n";
 	}
 	foreach $ip (@ips) {
 		print TARGET "com2sec local     $ip	$snmpd_conf{'__COMMUNITY__'}\n";


### PR DESCRIPTION
Necessary when master maps to localhost which almost always has ip6 available