### PR TITLE
Ignore empty trusted_ips field at get_sa_config function

### DIFF
--- a/bin/dump_mailscanner_config.pl
+++ b/bin/dump_mailscanner_config.pl
@@ -238,7 +238,7 @@ sub get_sa_config
   $config{'__PYZOR_TIMEOUT__'} = $row{'pyzor_timeout'};
 
   $config{'__TRUSTEDIPS__'} = ""; 
-  if ($row{'trusted_ips'}) { 
+  if ($row{'trusted_ips'} && $row{'trusted_ips'} ne 'no') {
     $config{'__TRUSTEDIPS__'} = join(" ", expand_host_string($row{'trusted_ips'},('dumper'=>'mailscanner/trustedips')));
   }
   $config{'__SA_RBLS__'} = $row{'sa_rbls'};


### PR DESCRIPTION
This PR fix a problem with the function **get_sa_config** when the configuration don't have **trusted IPs** and avoid the error:


> Did not understand hostlist entries 'no' in 'mailscanner/trustedips'

at the file **/var/mailcleaner/log/mailcleaner/dumper.log** and **dashboard/watchdog** systems.

[PR#380](https://github.com/MailCleaner/MailCleaner/pull/380) from @JohnMertz has the same base to fix **get_ms_config**, but I believe he forgot to apply the same code to the second function.
