### PR TITLE
Fix per-domain SpamC score overrides

### DIFF
--- a/bin/dump_custom_spamc_rules.pl
+++ b/bin/dump_custom_spamc_rules.pl
@@ -32,18 +32,16 @@ sub print_custom_rule {
     my ($current_rule, $current_rule_w, $current_sender, @current_rule_domains) = @_;
 
     my ($rule, $score) = split(' ', $current_rule);
-    my $rule_string = "meta __RCPT_CUSTOM_$current_rule_w (";
-    foreach (@current_rule_domains) {
-        $rule_string .= " __RCPT_$_ ||"
-    }
-    $rule_string =~ s/\|\|$//;
-    $rule_string .= ")\n";
-    print RULEFILE $rule_string;
     print RULEFILE "meta RCPT_CUSTOM_$current_rule_w ( $rule && ";
     if ($current_sender ne '') {
         print RULEFILE '__SENDER_' .$senders{$current_sender}. ' && ';
     }
-    print RULEFILE "__RCPT_CUSTOM_$current_rule_w )\n";
+    my $rcpt_string = " (";
+    foreach (@current_rule_domains) {
+        $rcpt_string .= " __RCPT_$_ ||"
+    }
+    $rcpt_string =~ s/\|\|$//;
+    print RULEFILE "$rcpt_string ) )\n";
     print RULEFILE "score RCPT_CUSTOM_$current_rule_w $score\n\n";
 }
 


### PR DESCRIPTION
SpamAssassin will "merge" identical rules, which means that only the first will be retained. As a result, for component rules generated for the same list of domains, only the first will be valid.

  meta __RULE1_RCPT_LIST ( __RCPT1 || __RCPT2 ) <- used
  meta __RULE2_RCPT_LIST ( __RCPT1 || __RCPT2 ) <- discarded

It does not create an alias, so any meta rule referencing the latter cannot hit.

Having the additional component rule for the recipient list was not necessary in the first place, since they were duplicated for every rule anyways. So, the fix is to simply not create any of these 'recipient list' component rules and instead just include the same '||' clause within the final meta rule.