### PR TITLE
Default DKIM

### DIFF
--- a/www/user/htdocs/vi.php
+++ b/www/user/htdocs/vi.php
@@ -52,7 +52,7 @@ if (! $spam->loadHeadersAndBody()) {
 
 // create view
 $template_ = new Template('vi.tmpl');
-if ($spam->getData('M_score') == "0.000")
+if ($spam->getData('M_score') == "NULL")
   $template_->setCondition('SCORENOTNULL', 0);
 else {
   $template_->setCondition('SCORENOTNULL', 1);


### PR DESCRIPTION
Bugfix for default DKIM pkey. Did not correctly detect the default DKIM domain and dump it to default.pkey.

Also includes a second commit to hide SpamC rules if no rules were hit. This patch does not currently work because the M_score column currently defaults to '0.000' on null. Future update should change this so that we can differentiate 'no score' from 'net zero score'.