### PR TITLE
Use custom init manager for Fail2Ban

### DIFF
--- a/etc/init.d/fail2ban-server
+++ b/etc/init.d/fail2ban-server
@@ -18,7 +18,7 @@
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-#   /etc/init.d/fail2ban: service management for Fail2Ban
+#   /etc/init.d/fail2ban: service management for Fail2Ban server
 
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ use warnings;
 use lib '/usr/mailcleaner/lib';
 use ManageServices;
 
-our $service = 'fail2ban';
+our $service = 'fail2ban-server';
 
 my $manager = ManageServices->new( 'autoStart' => 0 ) || die "Failed to create object: $!\n";
 $manager->loadModule($service) || die "Could not load module for service: $service\n";

--- a/lib/ManageServices.pm
+++ b/lib/ManageServices.pm
@@ -53,7 +53,7 @@ our %defaultActions = (
 		'desc'		=> 'get current status',
 		'cmd'		=> sub { 
 			my $self = shift;
-			return $self->status(0);
+			return $self->status();
 		},
 	},
 	'enable'	=> {
@@ -74,7 +74,7 @@ our %defaultActions = (
 		'desc'		=> 'get process id(s) for service',
 		'cmd'		=> sub {
 			my $self = shift;
-			if ($self->status(0) == 7) {
+			if ($self->status() == 7) {
 				return $self->clearFlags(7);
 			}
 			my @pids = $self->pids();
@@ -205,11 +205,16 @@ sub getServices
 			#'module'	=> 'Exim',
 			#'critical'	=> 1,
 		#},
-		#'fail2ban'	=> {
-			#'name'		=> 'Fail2Ban',
-			#'module'	=> 'Fail2Ban',
-			#'critical'	=> 1,
-		#},
+		'fail2ban'	=> {
+			'name'		=> 'Fail2Ban',
+			'module'	=> 'Fail2Ban',
+			'critical'	=> 0,
+		},
+		'fail2ban-server'	=> {
+			'name'		=> 'Fail2Ban-Server',
+			'module'	=> 'Fail2BanServer',
+			'critical'	=> 0,
+		},
 		#'greylistd'	=> {
 			#'name'		=> 'Greylist daemon',
 			#'module'	=> 'GreylistD',
@@ -472,9 +477,15 @@ sub createModule
 sub status
 {
 	my $self = shift;
-	unless (defined($self->{'module'})) {
-		my $service = shift || die "Either run \$self->loadModule('service_name') first\nor run with service name: \$self->status('service_name')";
+	my $service = shift;
+	if (defined($service)) {
 		$self->loadModule($service);
+	} elsif (defined($self->{'service'})) {
+		$service = $self->{'service'};
+	} elsif (defined($self->{'module'})) {
+		$self->loadModule($self->{'name'});
+	} else {
+		die "Either run \$self->loadModule('service_name') first\nor run with service name: \$self->status('service_name')";
 	}
 	my $autoStart = shift;
 	unless (defined($autoStart)) {
@@ -536,12 +547,18 @@ sub status
 sub start
 {
 	my $self = shift;
-	unless (defined($self->{'module'})) {
-		my $service = shift || die "Either run \$self->loadModule('service_name') first\nor run with service name: \$self->start('service_name')";
+	my $service = shift;
+	if (defined($service)) {
 		$self->loadModule($service);
+	} elsif (defined($self->{'service'})) {
+		$service = $self->{'service'};
+	} elsif (defined($self->{'module'})) {
+		$self->loadModule($service);
+	} else {
+		die "Either run \$self->loadModule('service_name') first\nor run with service name: \$self->status('service_name')";
 	}
 
-	if ($self->status(0) == 7) {
+	if ($self->status() == 7) {
 		return $self->clearFlags(7);
 	}
 

--- a/lib/ManageServices/Fail2Ban.pm
+++ b/lib/ManageServices/Fail2Ban.pm
@@ -1,0 +1,112 @@
+#!/usr/bin/perl -w
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+package ManageServices::Fail2Ban;
+
+use strict;
+use warnings;
+
+our @ISA = "ManageServices";
+
+sub init 
+{
+	my $module = shift;
+	my $class = shift;
+	my $self = $class->SUPER::createModule( config($class) );
+	bless $self, 'ManageServices::Fail2Ban';
+
+	return $self;
+}
+
+sub config
+{
+	my $class = shift;
+
+	my $config = {
+		'name' 		=> 'fail2ban',
+		'cmndline'	=> 'fail2ban-server',
+		'cmd'		=> '/usr/bin/fail2ban-client',
+		'confpath'	=> $class->{'conf'}->getOption('USRDIR').'/etc/fail2ban/',
+		'logfile'	=> $class->{'conf'}->getOption('VARDIR').'/log/fail2ban/mc-fail2ban.log',
+		'user'		=> 'root',
+		'group'		=> 'root',
+		'daemonize'	=> 'yes',
+		'forks'		=> 0,
+		'nouserconfig'  => 'yes',
+		'syslog_facility' => '',
+		'debug'		=> 0,
+		'log_sets'	=> 'all',
+		'loglevel'	=> 'info',
+		'timeout'	=> 5,
+		'checktimer'	=> 10,
+		'actions'	=> {},
+	};
+	
+	return $config;
+}
+
+sub setup
+{
+	my $self = shift;
+	my $class = shift;
+
+	my $server = $class->SUPER::status('fail2ban-server');
+	unless ( $server == 1) {
+		$self->doLog("fail2ban-server is not running ($server). Starting...", 'daemon');
+		$class->SUPER::start('fail2ban-server');
+		# Must reload 'fail2ban' config after operating on 'fail2ban-server'
+		$class->SUPER::loadModule('fail2ban');
+	}
+	
+	$self->doLog('Dumping Fail2Ban config...', 'daemon');
+	$ENV{'PYENV_VERSION'} = '3.7.7';
+	if (system($self->{'VARDIR'}.'/.pyenv/shims/dump_fail2ban_config.py')) {
+		$self->doLog('dump_fail2ban_config.py failed', 'daemon');
+	}
+
+	return 1;
+}
+
+sub preFork
+{
+	my $self = shift;
+	my $class = shift;
+
+	return 0;
+}
+
+sub mainLoop
+{
+	my $self = shift;
+	my $class = shift;
+	
+	if (!-e $class->{'conf'}->getOption('VARDIR').'/run/fail2ban') {
+		mkdir($class->{'conf'}->getOption('VARDIR').'/run/fail2ban')
+			|| die("Could not create ".$class->{'conf'}->getOption('VARDIR').'/run/fail2ban');
+	}
+	my $cmd = $self->{'cmd'} . " -c " . $self->{'confpath'} . " start";
+
+	$self->doLog("Running $cmd", 'daemon');
+	system($cmd);
+	
+	return 1;
+}
+
+1;

--- a/lib/ManageServices/Fail2BanServer.pm
+++ b/lib/ManageServices/Fail2BanServer.pm
@@ -1,0 +1,106 @@
+#!/usr/bin/perl -w
+#
+#   Mailcleaner - SMTP Antivirus/Antispam Gateway
+#   Copyright (C) 2021 John Mertz <git@john.me.tz>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+package ManageServices::Fail2BanServer;
+
+use strict;
+use warnings;
+
+our @ISA = "ManageServices";
+
+sub init 
+{
+	my $module = shift;
+	my $class = shift;
+	my $self = $class->SUPER::createModule( config($class) );
+	bless $self, 'ManageServices::Fail2BanServer';
+
+	return $self;
+}
+
+sub config
+{
+	my $class = shift;
+
+	my $config = {
+		'name' 		=> 'fail2ban-server',
+		'cmndline'	=> 'fail2ban-server',
+		'cmd'		=> '/usr/bin/fail2ban-server',
+		'pidfile'	=> '/var/run/fail2ban/fail2ban.pid',
+		'socket'	=> '/var/run/fail2ban/fail2ban.sock',
+		'logfile'	=> $class->{'conf'}->getOption('VARDIR').'/log/fail2ban/mc-fail2ban.log',
+		'user'		=> 'root',
+		'group'		=> 'root',
+		'daemonize'	=> 'yes',
+		'forks'		=> 0,
+		'nouserconfig'  => 'yes',
+		'syslog_facility' => '',
+		'debug'		=> 0,
+		'log_sets'	=> 'all',
+		'loglevel'	=> 'info',
+		'timeout'	=> 5,
+		'checktimer'	=> 10,
+		'actions'	=> {},
+	};
+	
+	return $config;
+}
+
+sub setup
+{
+	my $self = shift;
+	my $class = shift;
+
+	if (!-e '/var/run/fail2ban') {
+		mkdir('var/run/fail2ban')
+			|| die("Could not create /var/run/fail2ban");
+	}
+
+	$self->doLog('Dumping Fail2Ban config...', 'daemon');
+	$ENV{'PYENV_VERSION'} = '3.7.7';
+	if (system($self->{'VARDIR'}.'/.pyenv/shims/dump_fail2ban_config.py')) {
+		$self->doLog('dump_fail2ban_config.py failed', 'daemon');
+	}
+	
+	return 1;
+}
+
+sub preFork
+{
+	my $self = shift;
+	my $class = shift;
+
+	return 0;
+}
+
+sub mainLoop
+{
+	my $self = shift;
+	my $class = shift;
+	
+	my $cmd = $self->{'cmd'} . " -b -s " . $self->{'socket'} . " -p " . $self->{'pidfile'};
+
+	$self->doLog("Running $cmd", 'daemon');
+	system($cmd);
+	
+	return 1;
+}
+
+1;


### PR DESCRIPTION
Potential fix for Fail2Ban restart problem with large blacklist.

On our Cloud cluster Fail2Ban can fail to restart if it is restarted in quick succession. This is because the initial startup is not done starting when it tries to stop, then cannot start again because the first iteration is locking the socket.

The custom init library that I created a couple of years ago properly checks to see if the process is actually still running and will prevent this blocking.

It is possible to resolve this in the existing init script, but this also allows for Fail2Ban to be added to the CheckAll function which means that it can be restarted automatically if all else fails.