### PR TITLE
REJECT instead of DROP items in BLACKLIST

### DIFF
--- a/bin/dump_firewall.pl
+++ b/bin/dump_firewall.pl
@@ -282,7 +282,7 @@ sub do_start_script
 				$blacklist = 1;
 				foreach my $IP (<BLACK_IP>) {
 					chomp($IP);
-					print BLACKLIST "$iptables -I BLACKLIST 1 -s $IP -j DROP\n";
+					print BLACKLIST "$iptables -I BLACKLIST 1 -s $IP -j REJECT\n";
 				}
 				close BLACKLIST;
 				close BLACK_IP;


### PR DESCRIPTION
This at least allows connections to be traceable so that we can have information on whether it is safe to remove IPs that may no longer be abusive.