### PR TITLE
Enhance TLS certificate support

### DIFF
--- a/etc/exim/exim_stage1.conf_template_4.96
+++ b/etc/exim/exim_stage1.conf_template_4.96
@@ -188,24 +188,6 @@ begin acl
 
 acl_check_conn:
 
-warn
-   encrypted = *
-   ! verify = certificate
-   condition = ${if def:tls_in_peerdn {yes}{no}}
-   add_header = X-TLS-Client-Certificate: invalid (${tls_peerdn})
-   log_message = Invalid TLS client certificate presented (${tls_peerdn}).
-
-warn
-   encrypted = *
-   ! verify = certificate
-   condition = ${if def:tls_peerdn {no}{yes}}
-  log_message = No TLS client certificate presented.
-
-warn
-   verify = certificate
-   add_header = X-TLS-Client-Certificate: valid
-   condition = false
-
 __IF__ RATELIMIT
 warn ratelimit          = __RATELIMIT_RULE__
           !hosts        = <; 127.0.0.1 ; +trusted_hosts ; +no_ratelimit_hosts
@@ -287,7 +269,8 @@ __FI__
  __IF__ DEBUG
           logwrite      = DEBUG - refused, bad helo - smtp:refused,smtp:refused:bad_helo
  __FI__
-    accept hosts        = *
+
+  accept  hosts  = *
 
 acl_check_mail:
   # deny if no HELO command given
@@ -971,6 +954,38 @@ __FI__
   accept
 
 acl_check_data:
+
+__IF__ USETLS
+  warn	  !encrypted = *
+          remove_header = X-MailCleaner-TLS-Client-Certificate
+          add_header = X-MailCleaner-TLS-Client-Certificate: not encrypted
+ __IF__ DEBUG
+          logwrite = Message not encrypted with TLS.
+ __FI__
+
+  warn	  encrypted = *
+          !verify = certificate
+          condition = ${if def:tls_in_peerdn {yes}{no}}
+          remove_header = X-MailCleaner-TLS-Client-Certificate
+          add_header = X-MailCleaner-TLS-Client-Certificate: invalid (${tls_peerdn})
+ __IF__ DEBUG
+          logwrite = Invalid TLS client certificate presented (${tls_peerdn}).
+ __FI__
+
+  warn	  encrypted = *
+          !verify = certificate
+          condition = ${if def:tls_in_peerdn {no}{yes}}
+          remove_header = X-MailCleaner-TLS-Client-Certificate
+          add_header = X-MailCleaner-TLS-Client-Certificate: none
+ __IF__ DEBUG
+          logwrite = No TLS client certificate presented.
+ __FI__
+
+  warn	  encrypted = *
+	  verify = certificate
+          remove_header = X-MailCleaner-TLS-Client-Certificate
+          add_header = X-MailCleaner-TLS-Client-Certificate: valid
+__FI__
 
   warn    set acl_m_linelength_limit = 998
           condition = ${if >{$max_received_linelength}{$acl_m_linelength_limit}}

--- a/etc/exim/exim_stage1.conf_template_4.96
+++ b/etc/exim/exim_stage1.conf_template_4.96
@@ -34,9 +34,11 @@ __FI__
 
 __IF__ USETLS
 tls_advertise_hosts = *
+tls_try_verify_hosts = *
 tls_certificate = __VARDIR__/spool/tmp/exim/certificate
 tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
 tls_require_ciphers = __CIPHERS__
+tls_verify_certificates = /etc/ssl/certs/ca-certificates.crt
 openssl_options = +no_sslv2 +no_sslv3
 __ELSE__ USETLS
 tls_advertise_hosts =
@@ -185,6 +187,24 @@ perl_startup = do '__SRCDIR__/etc/exim/stage1_scripts.pl'
 begin acl
 
 acl_check_conn:
+
+warn
+   encrypted = *
+   ! verify = certificate
+   condition = ${if def:tls_in_peerdn {yes}{no}}
+   add_header = X-TLS-Client-Certificate: invalid (${tls_peerdn})
+   log_message = Invalid TLS client certificate presented (${tls_peerdn}).
+
+warn
+   encrypted = *
+   ! verify = certificate
+   condition = ${if def:tls_peerdn {no}{yes}}
+  log_message = No TLS client certificate presented.
+
+warn
+   verify = certificate
+   add_header = X-TLS-Client-Certificate: valid
+   condition = false
 
 __IF__ RATELIMIT
 warn ratelimit          = __RATELIMIT_RULE__
@@ -1319,6 +1339,11 @@ __FI__
 __FI__
 __IF__ USETLS
   hosts_require_tls = <; ${if match_domain{$domain}{+domains_require_tls_to:+local_domains_require_outgoing_tls} {*}{__HOSTS_REQUIRE_TLS__} }
+  tls_try_verify_hosts = *
+  tls_certificate = __VARDIR__/spool/tmp/exim/certificate
+  tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
+  tls_require_ciphers = __CIPHERS__
+  tls_verify_certificates = /etc/ssl/certs/ca-certificates.crt
 __FI__
   return_path = ${if and { \
                              {def:return_path} \

--- a/etc/exim/exim_stage4.conf_template_4.96
+++ b/etc/exim/exim_stage4.conf_template_4.96
@@ -37,9 +37,11 @@ timeout_frozen_after = 1h
 
 __IF__ USETLS
 tls_advertise_hosts = *
+tls_try_verify_hosts = *
 tls_certificate = __VARDIR__/spool/tmp/exim/certificate
 tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
 tls_require_ciphers = __CIPHERS__
+tls_verify_certificates = /etc/ssl/certs/ca-certificates.crt
 __ELSE__ USETLS
 tls_advertise_hosts =
 __FI__
@@ -346,6 +348,11 @@ remote_smtp:
   connect_timeout = 30s
 __IF__ USETLS
   hosts_require_tls = <; ${if match_domain{$domain}{+domains_require_tls_to} {*}{__HOSTS_REQUIRE_TLS__} }
+  tls_try_verify_hosts = *
+  tls_certificate = __VARDIR__/spool/tmp/exim/certificate
+  tls_privatekey = __VARDIR__/spool/tmp/exim/privatekey
+  tls_require_ciphers = __CIPHERS__
+  tls_verify_certificates = /etc/ssl/certs/ca-certificates.crt
 __FI__
   hosts_try_chunking =
 __IF__ ALLOW_LONG

--- a/etc/exim/stage4/remove_headers_template
+++ b/etc/exim/stage4/remove_headers_template
@@ -1,1 +1,1 @@
-headers_remove = X-MailCleaner-recipients : X-MailCleaner-sender_address : X-MailCleaner-return_path
+headers_remove = X-MailCleaner-recipients : X-MailCleaner-sender_address : X-MailCleaner-return_path : X-MailCleaner-TLS-Client-Certificate

--- a/share/spamassassin/70_mc_tls.cf
+++ b/share/spamassassin/70_mc_tls.cf
@@ -1,0 +1,15 @@
+header		MC_CLIENT_UNENCRYPTED	X-MailCleaner-TLS-Client-Certificate =~ /\bnot encrypted\b/i
+describe 	MC_CLIENT_UNENCRYPTED	Unencrypted connection from Client
+score	 	MC_CLIENT_UNENCRYPTED	0.1
+
+header		MC_CLIENT_CERT_VALID	X-MailCleaner-TLS-Client-Certificate =~ /\bvalid\b/i
+describe 	MC_CLIENT_CERT_VALID	Valid TLS client certificate presented
+score	 	MC_CLIENT_CERT_VALID	0.001
+
+header		MC_CLIENT_CERT_INVALID	X-MailCleaner-TLS-Client-Certificate =~ /\binvalid\b/i
+describe	MC_CLIENT_CERT_INVALID	Invalid TLS client certificate presented
+score	 	MC_CLIENT_CERT_INVALID	1
+
+header		MC_CLIENT_CERT_NONE	X-MailCleaner-TLS-Client-Certificate =~ /\bnone\b/i
+describe	MC_CLIENT_CERT_NONE	No TLS client certificate presented
+score	 	MC_CLIENT_CERT_NONE	0.1


### PR DESCRIPTION
Add optional client certificate validation for inbound mail, log result to new header.

Force presentation of client certificate for outbound mail.

Both apply only when USETLS is enabled.