### PR TITLE
Swap 'Version' value with 'Patch level' value.

### DIFF
--- a/www/guis/admin/public/templates/default/scripts/ajax/monitorstatus/hoststatus.phtml
+++ b/www/guis/admin/public/templates/default/scripts/ajax/monitorstatus/hoststatus.phtml
@@ -149,11 +149,11 @@
     <td class="c_processes" >
 <span class="procrow">
   <span class='statusdescr'><?php echo $this->t->_('Version');?> : </span>
-  <span class='versionstatus'><?php echo $this->slave->getHostVersion();?></span>
+  <span class='versionstatus'><?php echo $this->slave->getHostPatchLevel();?></span>
 </span>
 <span class="procrow finalprocrow">
   <span class='statusdescr'><?php echo $this->t->_('Patch level');?> : </span>
-  <span class='versionstatus'><?php echo $this->slave->getHostPatchLevel();?></span>
+  <span class='versionstatus'><?php echo $this->slave->getHostVersion();?></span>
 </span>
 
      <?php $processes = array('exim_stage1' => array('advanced' => 0, 'actions' => array('stop', 'start', 'restart')), 


### PR DESCRIPTION
These values were previously redundant. The 'Version' has been changed be meaningful by including the installed patch number and the Git commit hash. This is done in U4MC.

The patch level, eg. "2023100301", makes more sense as a version number, and vice versa (eg. 83-03dd071). This commit simply swaps the values associated with each label in the WebUI. It does not change the actual usage of these values on the back-end, since the version gets used in the SMTP banner and in that case, the commit hash and installed updates are more meaningful.