### PR TITLE
Purge all

### DIFF
--- a/www/classes/user/SpamQuarantine.php
+++ b/www/classes/user/SpamQuarantine.php
@@ -464,7 +464,7 @@ public function purge() {
      $clean_filters[$key] = $db_masterspool->sanitize($value);
    }
 
-   $query = "DELETE FROM spam_".$index." WHERE to_domain='".$clean_filters['to_domain']."' AND to_user='".$clean_filters['to_local']."'";
+   $query = "DELETE FROM spam_".$index." WHERE to_domain='".$clean_filters['to_domain']."' AND ( to_user='".$clean_filters['to_local']."' OR to_user like '".$clean_filters['to_local']."+%')";
 
    #return true;
    return $db_masterspool->doExecute($query);

--- a/www/user/htdocs/lang/en/texts.php
+++ b/www/user/htdocs/lang/en/texts.php
@@ -29,6 +29,7 @@ $txt['CLEAR'] = "clear";
 /*
  * generic texts
  */
+$txt['AND'] = "and";
 $txt['GB'] = "GB";
 $txt['MB'] = "MB";
 $txt['KB'] = "KB";

--- a/www/user/htdocs/purge.php
+++ b/www/user/htdocs/purge.php
@@ -27,22 +27,58 @@ $doit = false;
 // check if user has confirmed
 if (isset($_GET['doit'])) {
   $doit = true;
-  // get posted values
-  $form = new Form('filter', 'GET', $_SERVER['PHP_SELF']);
-  $posted = $form->getResult();
-  // get quarantine object
-  $quarantine = new SpamQuarantine();
-  $quarantine->setSettings($posted);
-  // do the purge
-  if ($quarantine->purge()) {
-    $res = $lang_->print_txt_param('PURGEDONE', $quarantine->getSearchAddress());
+  if (gettype($_GET['a']) == string) {
+    // get posted values
+    $form = new Form('filter', 'GET', $_SERVER['PHP_SELF']);
+    $posted = $form->getResult();
+    // get quarantine object
+    $quarantine = new SpamQuarantine();
+    $quarantine->setSettings($posted);
+    // do the purge
+    if ($quarantine->purge()) {
+      $res = $lang_->print_txt_param('PURGEDONE', $quarantine->getSearchAddress());
+    } else {
+      $res = $lang_->print_txt_param('COULDNOTPURGE', $quarantine->getSearchAddress());
+    }
   } else {
-    $res = $lang_->print_txt_param('COULDNOTPURGE', $quarantine->getSearchAddress());
+    $form = new Form('filter', 'GET', $_SERVER['PHP_SELF']);
+    $posted = $form->getResult();
+    $addresses = $posted['a'];
+    $res = '';
+    $quarantine = new SpamQuarantine();
+    foreach ($addresses as $a) {
+      $posted['a'] = $a;
+      if ($user_->hasAddress($a)) {
+        $quarantine->setSettings($posted);
+        if ($quarantine->purge()) {
+          $res .= $lang_->print_txt_param('PURGEDONE', $quarantine->getSearchAddress())."<br/>";
+        } else {
+          $res .= $lang_->print_txt_param('COULDNOTPURGE', $quarantine->getSearchAddress())."<br/>";
+        }
+      }
+    }
   }
 } else {
-    if (isset($_GET['a']) && $user_->hasAddress($_GET['a'])) {
-      $res = $lang_->print_txt_mparam('ASKPURGECONFIRM', array($_GET['days'], $_GET['a']));
+  if (isset($_GET['a'])) {
+    if (gettype($_GET['a']) == 'string') {
+      if ($user_->hasAddress($_GET['a'])) {
+        $res = $lang_->print_txt_mparam('ASKPURGECONFIRM', array($_GET['days'], $_GET['a']));
+      } else {
+        $res = $lang_->print_txt('DESTNOTVALID');
+	//$doit = false;
+      }
+    } else {
+      $addresses = [];
+      foreach ($_GET['a'] as $a) {
+        if ($user_->hasAddress($a)) {
+          $addresses[] = $a;
+        }
+      }
+      $addstr = implode(", ", $addresses);
+      $addstr = preg_replace('/, ([^,]*)$/', "</strong> ".$lang_->print_txt('AND')." <strong>$1", $addstr);
+      $res = $lang_->print_txt_mparam('ASKPURGECONFIRM', array($_GET['days'], $addstr));
     }
+  }
 }
 
 // create view
@@ -55,7 +91,7 @@ if ($doit) {
 $replace = array(
   '__INCLUDE_JS__' => "<script type=\"text/javascript\" charset=\"utf-8\">
                         function confirmation() {
-                          window.location.href=\"".$_SERVER['PHP_SELF']."?".preg_replace('/&/', ';', $_SERVER['QUERY_STRING']."&doit=1")."\";
+                          window.location.href=\"".$_SERVER['PHP_SELF']."?".$_SERVER['QUERY_STRING']."&doit=1\";
                         }
                        </script>",
   '__MESSAGE__' => $res,

--- a/www/user/htdocs/quarantine.php
+++ b/www/user/htdocs/quarantine.php
@@ -173,6 +173,7 @@ $replace = array(
     '__END_FILTER_FORM__' => $form->close(),//	
 	'__SEND_SUMMARY_LINK__' => "summary.php?".$get_query,
 	'__PURGE_LINK__' => "purge.php?".$get_query,
+	'__PURGE_FUNC__' => "purge",
     '__REFRESH_BUTTON__' => $form->submit('submit', $lang_->print_txt('REFRESH'), ''),
     '__SEARCH_BUTTON__' => $form->submit('submit', $lang_->print_txt('SEARCH'), ''),
     '__REFRESH_LINK__' => "javascript:window.document.forms['".$form->getName()."'].submit();",
@@ -223,7 +224,11 @@ $replace = array(
     "__GROUPQUARANTINES__" => $form->checkbox('group_quarantines', '1', $quarantine->getFilter('group_quarantines'), 'javascript=groupAddresses();', 1),
     "__SPAMONLY__" => $form->checkbox('spam_only', '1', (!$quarantine->getFilter('newsl_only') && $quarantine->getFilter('spam_only')), 'javascript=showSpamOnly();', 1),
     "__NEWSLONLY__" => $form->checkbox('newsl_only', '1', (!$quarantine->getFilter('spam_only') && $quarantine->getFilter('newsl_only')), 'javascript=showNewslOnly();', 1),
+    "__ALL_ADDRESSES__" => '[ "'.join('", "', $user_addresses_).'" ]',
 );
+if ($quarantine->getFilter('group_quarantines')) {
+    $replace['__PURGE_FUNC__'] = "purge_all";
+}
 
 // display page
 $template_->output($replace);

--- a/www/user/htdocs/templates/default/quarantine.tmpl
+++ b/www/user/htdocs/templates/default/quarantine.tmpl
@@ -33,6 +33,7 @@
    var info_width = 500;
    var info_height = 500;
    var email_address = '__EMAIL_ADDRESS__';
+   var addresses = __ALL_ADDRESSES__;
    var lang = '__LANG__';
    var nb_days = '__NB_DAYS__';
    var mask_forced = '__MASK_FORCED__';
@@ -200,7 +201,7 @@ __DEFAULT__ sep = |
     __PREVIOUS_PAGE__ __PAGE_SEP__ __NEXT_PAGE__ __PAGE_SEP____PAGES__</td>
   </tr>
 </table>
-<p class="quickactions"><img src="images/trash.png" alt="__LANG_PURGESELECTEDSPAMS__" /><a href="javascript:purge();">__LANG_PURGESELECTEDSPAMS__</a></p>
+<p class="quickactions"><img src="images/trash.png" alt="__LANG_PURGESELECTEDSPAMS__" /><a href="javascript:__PURGE_FUNC__();">__LANG_PURGESELECTEDSPAMS__</a></p>
  <p class="quickactions"><img src="images/rapport.png" alt="__LANG_SENDSUM__" /><a href="javascript:summary();">__LANG_SENDSUM__</a> </p>
 <p id="purgeinfos">__DISPLAYEDINFOS__ __PURGEINFOS__</p>
 

--- a/www/user/htdocs/templates/default/scripts/quarantine.js
+++ b/www/user/htdocs/templates/default/scripts/quarantine.js
@@ -79,6 +79,16 @@ function purge() {
   window.open('purge.php?a='+ encodeURIComponent(email_address)+'&days='+nb_days+'&mask_forced='+mask_forced, '', 'width='+popup_width+',height='+popup_height+',toolbar=0,resizable=1,scrollbars=0,status=0');
 }
 
+function purge_all() {
+  all = '';
+  i = 0;
+  addresses.forEach(function(a) {
+    all += 'a['+i+']='+encodeURIComponent(a)+'&';
+    i++;
+  });
+  window.open('purge.php?'+all+'days='+nb_days+'&mask_forced='+mask_forced, '', 'width='+popup_width+',height='+popup_height+',toolbar=0,resizable=1,scrollbars=0,status=0');
+}
+
 function analyse(msgid, storeid, to) {
   window.open('send_to_analyse.php?a='+ encodeURIComponent(to) +'&id='+msgid+'&s='+storeid+'&lang='+lang+'&pop=up', '', 'width='+popup_width+',height='+popup_height+',toolbar=0,resizable=1,scrollbars=0,status=0');
 }


### PR DESCRIPTION
When a sure is viewing all addresses in their quarantine (checkbox enabled), the purge option will now clear messages for all addresses, not just the primary.

This requires an update to custom templates file:

www/user/htdocs/templates/<name>/quarantine.tmpl

Without that change, the regular 'purge()' function will still be used, so the same old behaviour will be used, but nothing will break.