### PR TITLE
Update maillog.size for check_db.pl

### DIFF
--- a/install/dbs/t_st_maillog.sql
+++ b/install/dbs/t_st_maillog.sql
@@ -4,7 +4,7 @@ DROP TABLE IF EXISTS maillog;
 CREATE TABLE maillog (
   timestamp timestamp NOT NULL,
   id text,
-  size bigint default '0',
+  size bigint(20) default '0',
   from_address text,
   from_domain text,
   to_address text,


### PR DESCRIPTION
maillog.size has no size definition for bigint which is why check_db.pl wants to repair it every time.  
`INCORRECT column type 'bigint(20)' != 'bigint' maillog.size FIXED !`

Set the size to 20 as it is already specified in the DB