### PR TITLE
Prevent slave interface from locking up

### DIFF
--- a/www/guis/admin/public/js/index.js
+++ b/www/guis/admin/public/js/index.js
@@ -18,9 +18,13 @@ countspaused = false;
 
 $(document).ready(function(){
 
-	loadstatus();
-        loadcounts();
-	window.setInterval(loadcounts, 5000);
+	if (loadstatus()) {
+		if (loadcounts()) {
+			window.setInterval(loadcounts, 5000);
+		} else {
+			$("#countsbloc"+previousblock).html("timedout");
+		}
+	}
 	alignStats();
 	
 	$('#globalstatsbloc').hover( 
@@ -64,7 +68,7 @@ function loadcounts() {
 		  timeout: 10000,
 		  dataType: "html",
 		  success: function(msg){
-            loadingcounts = false;
+			loadingcounts = false;
 			if (msg == '') {
 				loadcounts();
 			} else {
@@ -90,13 +94,17 @@ function loadcounts() {
           },
           error: function() {
         	  $("#countsbloc"+currentblock).html('timed out');
-        	  loadingcounts = false;
+        	  loadingcounts = "timedout";
+        	  countspaused = true;
+		  return false;
           }
 		});
+          return true;
 }
 
 function loadstatus() {
 	if (loadingstatus) {
+      	  $("#globalstatusbloc").html('already loading');
 		return;
 	}
 	loadingstatus = true;
@@ -114,7 +122,9 @@ function loadstatus() {
         },
         error: function() {
       	  $("#globalstatusbloc").html('timed out');
-      	  loadingstatus = false;
+      	  loadingstatus = "timedout";
+          return false;
         }
 		});
+        return true;
 }

--- a/www/guis/admin/public/js/quickstatus.js
+++ b/www/guis/admin/public/js/quickstatus.js
@@ -10,7 +10,6 @@ var hostreloadtime = 5000;
 var graphStatus = new Array();
 
 $(document).ready(function(){
-	
 	$("#statusreloadimg").click(function(event){
         loading();
         event.preventDefault();
@@ -24,6 +23,11 @@ $(document).ready(function(){
 });
 
 function loading() {
+	if (slave) {
+            $("#statuspanel").html("not running on slave");
+		return;
+	}
+	
 	$("#statuspanel").html(loadinghtml);
 	statusrequest = $.ajax({
 		  type: "GET",


### PR DESCRIPTION
Remove unnecessary calls to SOAP interface that won't actually be displayed.

Also help prevent locking on master home page by abandoning status reloads if first fails.