### PR TITLE
Ignore invalid options

### DIFF
--- a/bin/push_stats.sh
+++ b/bin/push_stats.sh
@@ -57,13 +57,6 @@ for OPTION in "$@"; do
        fi
        days=$OPTION
        ;;
-    \-*)
-       ;;
-    *)
-       echo Invalid argument $OPTION
-       usage
-       exit
-       ;;
   esac
 done
 


### PR DESCRIPTION
For some reason '-r' is invalid when passed from 'system()' in mailcleaner_cron.pl