### PR TITLE
Better address truncation

### DIFF
--- a/bin/send_summary.pl
+++ b/bin/send_summary.pl
@@ -399,8 +399,19 @@ sub getQuarantineTemplate {
       $s_local = $1;
       $s_domain = $2;
       if ($type eq 'html') {
-        $s_local =~  s/^(\S{20}).*$/\1.../;
-  	$s_domain =~  s/^(\S{20}).*$/\1.../;
+        my $totallen = 50;
+        unless (length($s_local) + length($s_domain) < $totallen) {
+          if (length($s_local) > $totallen/2 && length($s_domain) > $totallen/2) {
+            $s_local = substr($s_local, 0, $totallen/2);
+            $s_domain = substr($s_domain, 0, $totallen/2);
+          } elsif (length($s_local) > $totallen/2) {
+            if (length($s_local) > $totallen-length($s_domain)) {
+              $s_local = substr($s_local, 0, $totallen-length($s_domain))."...";
+            } 
+          } elsif (length($s_domain) > $totallen-length($s_local)) {
+            $s_domain = substr($s_domain, 0, $totallen-length($s_local))."...";
+          }
+        }
       }
     }
 

--- a/www/classes/user/Spam.php
+++ b/www/classes/user/Spam.php
@@ -123,8 +123,27 @@ public function getAllData() {
     $data = $this->getData($field);
     $data = iconv_mime_decode($data, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
     $ret = htmlentities($data, ENT_COMPAT, "UTF-8");
-    if (isset($split_fields[$field])) {
-      $ret = substr($ret, 0, $split_fields[$field]);
+    if ($field == 'M_subject') {
+      return substr($ret, 0, $split_fields[$field]);
+    } elseif ($field == 'to' || $field == 'sender') {
+      if (preg_match('/(\S+)\@(\S+)/', $ret, $matches)) {
+        if (strlen($matches[1]) + strlen($matches[2]) < $split_fields[$field]) {
+          return $matches[1]."@".$matches[2];
+        } else {
+          if (strlen($matches[1]) > $split_fields[$field]/2 && strlen($matches[2]) > $split_fields[$field]/2) {
+            return substr($matches[1], 0, $split_fields[$field]/2)."...@".substr($matches[2], 0, $split_fields[$field]/2);
+          } elseif (strlen($matches[1]) > $split_fields[$field]/2) {
+            if (strlen($matches[1]) > $split_fields[$field]-strlen($matches[2])) {
+              return substr($matches[1], 0, $split_fields[$field]-strlen($matches[2]))."...@$matches[2]";
+            }
+            return $matches[1]."@".$matches[2];
+          }
+          if (strlen($matches[2]) > $split_fields[$field]-strlen($matches[1])) {
+            return "$matches[1]@".substr($matches[2], 0, $split_fields[$field]-strlen($matches[1]))."...";
+          }
+          return $matches[1]."@".$matches[2];
+        }
+      }
     }
     return $ret;
  }

--- a/www/guis/admin/application/models/QuarantinedSpam.php
+++ b/www/guis/admin/application/models/QuarantinedSpam.php
@@ -115,24 +115,25 @@ class Default_Model_QuarantinedSpam
        $this->_destination = $local."@".$domain;
     }
     public function getCleanAddress($address) {
-      $locallen = 25;
-      $domainlen = 25;
+      $totallen = 50;
       $address = htmlspecialchars($address);
       if (preg_match('/(\S+)\@(\S+)/', $address, $matches)) {
-        $str = "";
-        if (strlen($matches[1]) > $locallen) {
-          $str .= substr($matches[1], 0, $locallen)."...";
+        if (strlen($matches[1]) + strlen($matches[2]) < $totallen) {
+          return $matches[1]."@".$matches[2];
         } else {
-          $str .= $matches[1];
+          if (strlen($matches[1]) > $totallen/2 && strlen($matches[2]) > $totallen/2) {
+            return substr($matches[1], 0, $totallen/2)."...@".substr($matches[2], 0, $totallen/2);
+          } elseif (strlen($matches[1]) > $totallen/2) {
+            if (strlen($matches[1]) > $totallen-strlen($matches[2])) {
+              return substr($matches[1], 0, $totallen-strlen($matches[2]))."...@$matches[2]";
+            }
+            return $matches[1]."@".$matches[2];
+          }
+          if (strlen($matches[2]) > $totallen-strlen($matches[1])) {
+            return "$matches[1]@".substr($matches[2], 0, $totallen-strlen($matches[1]))."...";
+          }
+          return $matches[1]."@".$matches[2];
         }
-
-        $str.="@";
-        if (strlen($matches[2]) > $domainlen) {
-          $str .= substr($matches[2], 0, $domainlen)."...";
-        } else {
-          $str .= $matches[2];
-        }
-        return $str;
       }
       return $address;
     }


### PR DESCRIPTION
Set max truncation length for whole address (plus @ and ...). Then allow domain and local to share the full length, rather than being limited to 1/2 of the total length.

Previously an address with a 4 char local and 50 char domain would display as: 1234@first25charsoflongdomain...
Now the domain can borrow the remaining 21 characters from local to display: 1234@first46charsoflongdomainnamethatjustkeepsgoi... This will allow an address with eg. 4 char local and 46 char domain to not be truncated at all.

It looked odd previously with very uneven potential truncations:

user@26characterlongdomain.name...
alsoa26characterlongusern...@domain.com
usernameunder25chars@domainnameunder25.chars
thisisamuchlongerusernam...@alsoataverylongdomainname...

This should even it out a lot more. Same algorithm used for report, user and admin quarantines.